### PR TITLE
Refactor data loader TUI metrics layout

### DIFF
--- a/csrc/loader/data_loader_metrics.h
+++ b/csrc/loader/data_loader_metrics.h
@@ -14,20 +14,7 @@ namespace lczero {
 namespace training {
 
 void UpdateFrom(QueueMetricProto& dest, const QueueMetricProto& src);
-void UpdateFrom(FilePathProviderMetricsProto& dest,
-                const FilePathProviderMetricsProto& src);
-void UpdateFrom(ChunkSourceLoaderMetricsProto& dest,
-                const ChunkSourceLoaderMetricsProto& src);
-void UpdateFrom(ShufflingChunkPoolMetricsProto& dest,
-                const ShufflingChunkPoolMetricsProto& src);
-void UpdateFrom(ChunkRescorerMetricsProto& dest,
-                const ChunkRescorerMetricsProto& src);
-void UpdateFrom(ChunkUnpackerMetricsProto& dest,
-                const ChunkUnpackerMetricsProto& src);
-void UpdateFrom(ShufflingFrameSamplerMetricsProto& dest,
-                const ShufflingFrameSamplerMetricsProto& src);
-void UpdateFrom(TensorGeneratorMetricsProto& dest,
-                const TensorGeneratorMetricsProto& src);
+void UpdateFrom(CountMetricProto& dest, const CountMetricProto& src);
 void UpdateFrom(StageMetricProto& dest, const StageMetricProto& src);
 void UpdateFrom(DataLoaderMetricsProto& dest,
                 const DataLoaderMetricsProto& src);

--- a/csrc/loader/stages/chunk_rescorer.cc
+++ b/csrc/loader/stages/chunk_rescorer.cc
@@ -119,13 +119,14 @@ void ChunkRescorer::Worker(ThreadContext* context) {
 
 StageMetricProto ChunkRescorer::FlushMetrics() {
   StageMetricProto stage_metric;
-  auto* metrics = stage_metric.mutable_chunk_rescorer();
+  stage_metric.set_stage_type("chunk_rescorer");
+  LoadMetricProto aggregated_load;
+  aggregated_load.set_name("load");
   for (const auto& context : thread_contexts_) {
-    UpdateFrom(*metrics->mutable_load(),
-               context->load_metric_updater.FlushMetrics());
+    UpdateFrom(aggregated_load, context->load_metric_updater.FlushMetrics());
   }
-  *stage_metric.add_output_queue_metrics() =
-      MetricsFromQueue("output", output_queue_);
+  *stage_metric.add_load_metrics() = std::move(aggregated_load);
+  *stage_metric.add_queue_metrics() = MetricsFromQueue("output", output_queue_);
   return stage_metric;
 }
 

--- a/csrc/loader/stages/file_path_provider.cc
+++ b/csrc/loader/stages/file_path_provider.cc
@@ -94,10 +94,11 @@ void FilePathProvider::Stop() {
 
 StageMetricProto FilePathProvider::FlushMetrics() {
   StageMetricProto stage_metric;
-  auto* metrics = stage_metric.mutable_file_path_provider();
-  *metrics->mutable_load() = load_metric_updater_.FlushMetrics();
-  *stage_metric.add_output_queue_metrics() =
-      MetricsFromQueue("output", output_queue_);
+  stage_metric.set_stage_type("file_path_provider");
+  auto load_metrics = load_metric_updater_.FlushMetrics();
+  load_metrics.set_name("load");
+  *stage_metric.add_load_metrics() = std::move(load_metrics);
+  *stage_metric.add_queue_metrics() = MetricsFromQueue("output", output_queue_);
   return stage_metric;
 }
 

--- a/csrc/loader/stages/tensor_generator.cc
+++ b/csrc/loader/stages/tensor_generator.cc
@@ -5,6 +5,7 @@
 
 #include <cstring>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "absl/algorithm/container.h"
@@ -209,13 +210,14 @@ void TensorGenerator::ProcessPlanes(const std::vector<FrameType>& frames,
 
 StageMetricProto TensorGenerator::FlushMetrics() {
   StageMetricProto stage_metric;
-  auto* metrics = stage_metric.mutable_tensor_generator();
+  stage_metric.set_stage_type("tensor_generator");
+  LoadMetricProto aggregated_load;
+  aggregated_load.set_name("load");
   for (const auto& context : thread_contexts_) {
-    UpdateFrom(*metrics->mutable_load(),
-               context->load_metric_updater.FlushMetrics());
+    UpdateFrom(aggregated_load, context->load_metric_updater.FlushMetrics());
   }
-  *stage_metric.add_output_queue_metrics() =
-      MetricsFromQueue("output", output_queue_);
+  *stage_metric.add_load_metrics() = std::move(aggregated_load);
+  *stage_metric.add_queue_metrics() = MetricsFromQueue("output", output_queue_);
   return stage_metric;
 }
 

--- a/csrc/utils/metrics/load_metric.h
+++ b/csrc/utils/metrics/load_metric.h
@@ -79,6 +79,7 @@ class LoadMetricUpdater {
 
 // UpdateFrom function for LoadMetricProto - simple additive behavior
 inline void UpdateFrom(LoadMetricProto& dest, const LoadMetricProto& src) {
+  if (src.has_name()) dest.set_name(src.name());
   dest.set_load_seconds(dest.load_seconds() + src.load_seconds());
   dest.set_total_seconds(dest.total_seconds() + src.total_seconds());
 }

--- a/docs/loader_redesign.md
+++ b/docs/loader_redesign.md
@@ -203,6 +203,12 @@ message ChunkUnpackerConfig {
 `proto/training_metrics.proto`:
 
 ```proto
+message LoadMetricProto {
+  optional string name = 1;
+  optional double load_seconds = 2 [default = 0.0];
+  optional double total_seconds = 3 [default = 0.0];
+}
+
 message QueueMetricProto {
   optional string name = 1;
   optional uint64 put_count = 2 [default = 0];
@@ -212,15 +218,23 @@ message QueueMetricProto {
   optional uint64 queue_capacity = 6 [default = 0];
 }
 
+message CountMetricProto {
+  optional string name = 1;
+  optional uint64 count = 2 [default = 0];
+  optional uint64 capacity = 3;
+}
+
 message StageMetricProto {
   optional string name = 1;
-  optional FilePathProviderMetricsProto file_path_provider = 2;
-  optional ChunkSourceLoaderMetricsProto chunk_source_loader = 3;
-  optional ShufflingChunkPoolMetricsProto shuffling_chunk_pool = 4;
-  optional ChunkUnpackerMetricsProto chunk_unpacker = 5;
-  optional ShufflingFrameSamplerMetricsProto shuffling_frame_sampler = 6;
-  optional TensorGeneratorMetricsProto tensor_generator = 7;
-  repeated QueueMetricProto output_queue_metrics = 10;
+  optional string stage_type = 2;
+  repeated LoadMetricProto load_metrics = 3;
+  repeated QueueMetricProto queue_metrics = 4;
+  repeated CountMetricProto count_metrics = 5;
+  optional uint64 dropped = 6 [default = 0];
+  optional uint64 skipped_files_count = 7 [default = 0];
+  optional string last_chunk_key = 8;
+  optional string anchor = 9;
+  optional uint64 chunks_since_anchor = 10 [default = 0];
 }
 
 message DataLoaderMetricsProto {

--- a/docs/new_stage.md
+++ b/docs/new_stage.md
@@ -22,8 +22,9 @@ configurations.
   if the stage consumes upstream data.
 - Update `StageConfig` with an `optional <YourStage>Config` entry so the stage
   can be referenced from the `repeated stage` list.
-- If the stage emits custom metrics, add a corresponding message to
-  `proto/training_metrics.proto` and hang it off `StageMetricProto`.
+- If the stage emits custom metrics, extend `StageMetricProto` in
+  `proto/training_metrics.proto`. Prefer the existing `load_metrics`,
+  `queue_metrics`, and `count_metrics` collections when possible.
 - When the stage needs control requests or responses, extend
   `proto/stage_control.proto` so they can be carried through
   `StageControlRequest`/`StageControlResponse`.
@@ -60,9 +61,10 @@ configurations.
 - **Accumulate state** while workers run (e.g., load metrics, counters,
   queue statistics).
 - **`FlushMetrics()`** should snapshot the current values, reset internal
-  counters as needed, and populate the appropriate subsection of
-  `StageMetricProto`. Use helpers like `MetricsFromQueue("output", queue)` to
-  expose queue utilisation under `output_queue_metrics`.
+  counters as needed, and populate `StageMetricProto`. Set the
+  `stage_type` field so the UI can identify the stage kind. Use helpers like
+  `MetricsFromQueue("output", queue)` to expose queue utilisation under
+  `queue_metrics`, and append load information via `load_metrics`.
 - For multiple queues or distinct metric groups, add additional entries with
   meaningful names (`"output"`, `"prefetch"`, etc.) so downstream tooling can
   pick the right series.

--- a/proto/training_metrics.proto
+++ b/proto/training_metrics.proto
@@ -5,8 +5,9 @@ package lczero;
 // Load metric that accumulates seconds of load time.
 // Separate proto to support LoadMetricUpdaterProto functionality.
 message LoadMetricProto {
-  optional double load_seconds = 1 [default = 0.0];
-  optional double total_seconds = 2 [default = 0.0];
+  optional string name = 1;
+  optional double load_seconds = 2 [default = 0.0];
+  optional double total_seconds = 3 [default = 0.0];
 }
 
 // Statistics metric for integer values.
@@ -37,72 +38,24 @@ message QueueMetricProto {
   optional uint64 queue_capacity = 6 [default = 0];
 }
 
-// Metrics for FilePathProvider performance monitoring.
-// Replaces the old FilePathProviderMetrics struct.
-message FilePathProviderMetricsProto {
-  optional LoadMetricProto load = 1;
-  optional QueueMetricProto queue = 2;
-}
-
-// Metrics for ChunkSourceLoader performance monitoring.
-message ChunkSourceLoaderMetricsProto {
-  optional LoadMetricProto load = 1;
-  optional QueueMetricProto queue = 2;
-  optional uint64 skipped_files_count = 3 [default = 0];
-  optional string last_chunk_key = 4;
-}
-
-// Metrics for ShufflingChunkPool performance monitoring.
-message ShufflingChunkPoolMetricsProto {
-  optional LoadMetricProto indexing_load = 1;
-  optional LoadMetricProto chunk_loading_load = 2;
-  optional QueueMetricProto queue = 3;
-  optional StatisticsProtoInt64 chunk_sources_count = 4;
-  optional uint64 current_chunks = 5 [default = 0];
-  optional uint64 pool_capacity = 6 [default = 0];
-  optional int32 chunks_since_anchor = 7 [default = 0];
-  optional string anchor = 8;
-  optional StatisticsProtoInt64 dropped_chunks = 9;
-}
-
-// Metrics for ChunkRescorer performance monitoring.
-message ChunkRescorerMetricsProto {
-  optional LoadMetricProto load = 1;
-  optional QueueMetricProto queue = 2;
-}
-
-// Metrics for ChunkUnpacker performance monitoring.
-message ChunkUnpackerMetricsProto {
-  optional LoadMetricProto load = 1;
-  optional QueueMetricProto queue = 2;
-}
-
-// Metrics for ShufflingFrameSampler performance monitoring.
-message ShufflingFrameSamplerMetricsProto {
-  optional LoadMetricProto load = 1;
-  optional QueueMetricProto queue = 2;
-  optional uint64 reservoir_capacity = 3 [default = 0];
-  optional uint64 current_reservoir_size = 4 [default = 0];
-}
-
-// Metrics for TensorGenerator performance monitoring.
-message TensorGeneratorMetricsProto {
-  optional LoadMetricProto load = 1;
-  optional QueueMetricProto queue = 2;
+message CountMetricProto {
+  optional string name = 1;
+  optional uint64 count = 2 [default = 0];
+  optional uint64 capacity = 3;
 }
 
 // Top-level metrics for the DataLoader.
-// Replaces the old MetricGroup<FilePathProviderMetrics>.
 message StageMetricProto {
   optional string name = 1;
-  optional FilePathProviderMetricsProto file_path_provider = 2;
-  optional ChunkSourceLoaderMetricsProto chunk_source_loader = 3;
-  optional ShufflingChunkPoolMetricsProto shuffling_chunk_pool = 4;
-  optional ChunkUnpackerMetricsProto chunk_unpacker = 5;
-  optional ShufflingFrameSamplerMetricsProto shuffling_frame_sampler = 6;
-  optional TensorGeneratorMetricsProto tensor_generator = 7;
-  optional ChunkRescorerMetricsProto chunk_rescorer = 8;
-  repeated QueueMetricProto output_queue_metrics = 10;
+  optional string stage_type = 2;
+  repeated LoadMetricProto load_metrics = 3;
+  repeated QueueMetricProto queue_metrics = 4;
+  repeated CountMetricProto count_metrics = 5;
+  optional uint64 dropped = 6 [default = 0];
+  optional uint64 skipped_files_count = 7 [default = 0];
+  optional string last_chunk_key = 8;
+  optional string anchor = 9;
+  optional uint64 chunks_since_anchor = 10 [default = 0];
 }
 
 message DataLoaderMetricsProto {


### PR DESCRIPTION
## Summary
- replace the stage-specific TUI widgets with a generic StageWidget that renders all shared load, count, and stage fields from the unified metrics proto
- update the queue widget to support named queues, drop statistics, and multiple queue rows per stage
- teach the data pipeline pane to discover stages and queues dynamically and mount the new widgets in order

## Testing
- `just format`
- `just pre-commit`


------
https://chatgpt.com/codex/tasks/task_e_68dc4192f0b0833184d2202a54496caa