### PR TITLE
Drop linear warmup initial step offset

### DIFF
--- a/docs/example.textproto
+++ b/docs/example.textproto
@@ -98,8 +98,8 @@ model {
 }
 training {
   schedule {
-   steps_per_network: 250
-   chunks_per_network: 50000
+    steps_per_network: 250
+    chunks_per_network: 50000
   }
   checkpoint {
     path: "/home/crem/tmp/2025-09/lc0_training/checkpoint"
@@ -108,6 +108,17 @@ training {
   optimizer {
     nadamw { beta_1: 0.9 beta_2: 0.98 epsilon: 1e-7 weight_decay: 0.0001 }
     constant_lr { lr: 0.001 }
+    # linear_warmup_lr {
+    #   step: 0
+    #   lr: 0.0           # Start at zero to warm up.
+    #   step: 1500
+    #   lr: 0.0005        # Ramp linearly from 0 to 0.0005.
+    #   step: 2000
+    #   lr: 0.0005        # Hold the same rate after warmup.
+    #   # Steps before the first entry use lr[0]; after the last entry use
+    #   # lr[last]. For pretrained networks, set the first step to the
+    #   # network's existing global step.
+    # }
   }
   max_grad_norm: 10.0  # Global gradient-norm clip; omit or set to 0 to disable.
   losses {

--- a/proto/training_config.proto
+++ b/proto/training_config.proto
@@ -23,12 +23,22 @@ message OptimizerConfig {
   }
   oneof lr_schedule {
     ConstantLRSchedule constant_lr = 2;
+    LinearWarmupLRSchedule linear_warmup_lr = 4;
   }
   float momentum = 3;
 }
 
 message ConstantLRSchedule {
   float lr = 1;
+}
+
+message LinearWarmupLRSchedule {
+  // Optimizer steps that define the piecewise-linear learning-rate curve.
+  // The learning rate stays at lr[0] for steps before the first entry and
+  // at lr[last] for steps after the last entry.
+  repeated int32 step = 1;
+  // Learning-rate values paired with each step entry.
+  repeated float lr = 2;
 }
 
 message NadamwOptimizerConfig {

--- a/src/lczero_training/daemon/pipeline.py
+++ b/src/lczero_training/daemon/pipeline.py
@@ -128,9 +128,8 @@ class TrainingPipeline:
         )
 
         logger.info("Restoring checkpoint")
-        optimizer_tx = make_gradient_transformation(
-            self._config.training.optimizer
-        )
+        optimizer_config = self._config.training.optimizer
+        optimizer_tx = make_gradient_transformation(optimizer_config)
         jit_state = JitTrainingState(
             step=0,
             model_state=nnx.state(self._model),

--- a/src/lczero_training/training/optimizer.py
+++ b/src/lczero_training/training/optimizer.py
@@ -1,13 +1,52 @@
-from typing import Optional
-
+import jax.numpy as jnp
 import optax
 
-from proto.training_config_pb2 import OptimizerConfig
+from proto.training_config_pb2 import LinearWarmupLRSchedule, OptimizerConfig
+
+
+def _make_linear_warmup_schedule(
+    config: LinearWarmupLRSchedule,
+) -> optax.Schedule:
+    steps = jnp.asarray(config.step, dtype=jnp.float32)
+    lrs = jnp.asarray(config.lr, dtype=jnp.float32)
+
+    if steps.size != lrs.size:
+        raise ValueError(
+            "linear_warmup_lr.step and lr must have the same length"
+        )
+    if steps.size == 0:
+        raise ValueError("linear_warmup_lr requires at least one step")
+    if jnp.any(steps[1:] < steps[:-1]):
+        raise ValueError("linear_warmup_lr.step must be sorted ascending")
+
+    def schedule(count: jnp.ndarray) -> jnp.ndarray:
+        step = jnp.asarray(count, dtype=jnp.float32)
+
+        lower = jnp.searchsorted(steps, step, side="right") - 1
+        lower = jnp.clip(lower, 0, steps.size - 1)
+        upper = jnp.clip(lower + 1, 0, steps.size - 1)
+
+        left_step = steps[lower]
+        right_step = steps[upper]
+        left_lr = lrs[lower]
+        right_lr = lrs[upper]
+
+        progress = jnp.where(
+            right_step == left_step,
+            0.0,
+            (step - left_step) / (right_step - left_step),
+        )
+        progress = jnp.clip(progress, 0.0, 1.0)
+        return left_lr + progress * (right_lr - left_lr)
+
+    return schedule
 
 
 def make_lr_schedule(config: OptimizerConfig) -> optax.Schedule:
     if config.HasField("constant_lr"):
         return optax.constant_schedule(config.constant_lr.lr)
+    elif config.HasField("linear_warmup_lr"):
+        return _make_linear_warmup_schedule(config.linear_warmup_lr)
     else:
         raise ValueError(
             "Unsupported learning rate schedule: {}".format(
@@ -19,7 +58,7 @@ def make_lr_schedule(config: OptimizerConfig) -> optax.Schedule:
 def make_gradient_transformation(
     config: OptimizerConfig,
     *,
-    max_grad_norm: Optional[float] = None,
+    max_grad_norm: float | None = None,
 ) -> optax.GradientTransformation:
     lr_schedule = make_lr_schedule(config)
     if config.HasField("nadamw"):


### PR DESCRIPTION
## Summary
- remove the `linear_warmup_lr` initial_step option so schedules are defined by explicit step/lr points
- update the optimizer schedule builder and documentation to reflect defining pretrained anchors via point entries

## Testing
- `just format`
- `just pre-commit`


------
https://chatgpt.com/codex/tasks/task_e_68dcdfee5f608331900f5f6d3ed50d0a