### PR TITLE
Document weighted loss helper and remove empty-stack guard

### DIFF
--- a/docs/example.textproto
+++ b/docs/example.textproto
@@ -111,7 +111,17 @@ training {
   }
   max_grad_norm: 10.0  # Global gradient-norm clip; omit or set to 0 to disable.
   losses {
-    policy { name: "main" weight: 1.0 illegal_moves: MASK }
+    policy_crossentropy {
+      name: "main"
+      weight: 1.0
+      illegal_moves: MASK
+    }
+    policy_kl {
+      name: "main"
+      weight: 1.0
+      illegal_moves: MASK
+      temperature: 1.0  # Softmax temperature applied before KL evaluation
+    }
     value { name: "winner" weight: 1.0 }
     movesleft { name: "main" weight: 1.0 }
   }

--- a/docs/example.textproto
+++ b/docs/example.textproto
@@ -111,15 +111,17 @@ training {
   }
   max_grad_norm: 10.0  # Global gradient-norm clip; omit or set to 0 to disable.
   losses {
-    policy_crossentropy {
+    policy {
       name: "main"
       weight: 1.0
       illegal_moves: MASK
+      type: CROSS_ENTROPY
     }
-    policy_kl {
+    policy {
       name: "main"
       weight: 1.0
       illegal_moves: MASK
+      type: KL
       temperature: 1.0  # Softmax temperature applied before KL evaluation
     }
     value { name: "winner" weight: 1.0 }

--- a/proto/training_config.proto
+++ b/proto/training_config.proto
@@ -62,8 +62,7 @@ message PolicyLossWeightsConfig {
     CROSS_ENTROPY = 1;
     KL = 2;
   }
-  // Selects which policy loss implementation to use. Defaults to CROSS_ENTROPY
-  // when left unspecified.
+  // Selects which policy loss implementation to use. Must be specified.
   LossType type = 4;
   // Soft policy temperature applied before normalizing targets for KL loss.
   // Values <= 0 disable the adjustment and keep raw targets.

--- a/proto/training_config.proto
+++ b/proto/training_config.proto
@@ -44,7 +44,8 @@ message CheckpointConfig {
 }
 
 message LossWeightsConfig {
-  repeated PolicyLossWeightsConfig policy = 1;
+  repeated PolicyLossWeightsConfig policy_crossentropy = 1;
+  repeated PolicyKLLossWeightsConfig policy_kl = 4;
   repeated ValueLossWeightsConfig value = 2;
   repeated MovesLeftLossWeightsConfig movesleft = 3;
 }
@@ -57,6 +58,15 @@ message PolicyLossWeightsConfig {
     MASK = 1;
   }
   IllegalMoveHandling illegal_moves = 3;
+}
+
+message PolicyKLLossWeightsConfig {
+  string name = 1;
+  float weight = 2;
+  PolicyLossWeightsConfig.IllegalMoveHandling illegal_moves = 3;
+  // Soft policy temperature applied before normalizing targets. Values <= 0
+  // disable the adjustment and keep raw targets.
+  float temperature = 4;
 }
 
 message ValueLossWeightsConfig {

--- a/proto/training_config.proto
+++ b/proto/training_config.proto
@@ -44,8 +44,7 @@ message CheckpointConfig {
 }
 
 message LossWeightsConfig {
-  repeated PolicyLossWeightsConfig policy_crossentropy = 1;
-  repeated PolicyKLLossWeightsConfig policy_kl = 4;
+  repeated PolicyLossWeightsConfig policy = 1;
   repeated ValueLossWeightsConfig value = 2;
   repeated MovesLeftLossWeightsConfig movesleft = 3;
 }
@@ -58,15 +57,17 @@ message PolicyLossWeightsConfig {
     MASK = 1;
   }
   IllegalMoveHandling illegal_moves = 3;
-}
-
-message PolicyKLLossWeightsConfig {
-  string name = 1;
-  float weight = 2;
-  PolicyLossWeightsConfig.IllegalMoveHandling illegal_moves = 3;
-  // Soft policy temperature applied before normalizing targets. Values <= 0
-  // disable the adjustment and keep raw targets.
-  float temperature = 4;
+  enum LossType {
+    LOSS_TYPE_UNSPECIFIED = 0;
+    CROSS_ENTROPY = 1;
+    KL = 2;
+  }
+  // Selects which policy loss implementation to use. Defaults to CROSS_ENTROPY
+  // when left unspecified.
+  LossType type = 4;
+  // Soft policy temperature applied before normalizing targets for KL loss.
+  // Values <= 0 disable the adjustment and keep raw targets.
+  float temperature = 5;
 }
 
 message ValueLossWeightsConfig {

--- a/src/lczero_training/model/loss_function.py
+++ b/src/lczero_training/model/loss_function.py
@@ -1,44 +1,71 @@
-from typing import Dict, Protocol, Sequence, Tuple, TypeVar
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Sequence, Tuple
 
 import jax
 import jax.numpy as jnp
 import optax
-from jax import tree_util
+from jax.scipy.special import xlogy
 
 from proto.training_config_pb2 import (
     LossWeightsConfig,
+    PolicyKLLossWeightsConfig,
     PolicyLossWeightsConfig,
 )
 
 from .model import LczeroModel
 
 
-class Named(Protocol):
-    name: str
+@dataclass
+class _WeightedLoss:
+    """Callable loss along with the metric key and scalar weight.
 
+    The callable must accept the model predictions and targets for a given head
+    and return a per-example loss array whose shape matches the batch
+    dimensions of the inputs.
+    """
 
-T = TypeVar("T", bound=Named)
-
-
-def _find_head(field: Sequence[T], name: str) -> T:
-    return next(head for head in field if head.name == name)
+    key: str
+    weight: float
+    fn: Callable[[jax.Array, jax.Array], jax.Array]
 
 
 class LczeroLoss:
     def __init__(self, config: LossWeightsConfig):
         self.config = config
-        main_policy_config = _find_head(config.policy, "main")
-        winner_value_config = _find_head(config.value, "winner")
-        main_movesleft_config = _find_head(config.movesleft, "main")
+        self._policy_losses: List[_WeightedLoss] = [
+            _WeightedLoss(
+                key=f"policy_crossentropy_{cfg.name}",
+                weight=cfg.weight,
+                fn=PolicyCrossEntropyLoss(cfg),
+            )
+            for cfg in config.policy_crossentropy
+        ]
+        self._policy_losses.extend(
+            _WeightedLoss(
+                key=f"policy_kl_{cfg.name}",
+                weight=cfg.weight,
+                fn=PolicyKLLoss(cfg),
+            )
+            for cfg in config.policy_kl
+        )
 
-        self.weights = {
-            "policy": main_policy_config.weight,
-            "value": winner_value_config.weight,
-            "movesleft": main_movesleft_config.weight,
-        }
-        self.policy_loss = PolicyLoss(main_policy_config)
-        self.value_loss = ValueLoss()
-        self.movesleft_loss = MovesLeftLoss()
+        self._value_losses: List[_WeightedLoss] = [
+            _WeightedLoss(
+                key=f"value_{cfg.name}",
+                weight=cfg.weight,
+                fn=ValueLoss(),
+            )
+            for cfg in config.value
+        ]
+
+        self._movesleft_losses: List[_WeightedLoss] = [
+            _WeightedLoss(
+                key=f"movesleft_{cfg.name}",
+                weight=cfg.weight,
+                fn=MovesLeftLoss(),
+            )
+            for cfg in config.movesleft
+        ]
 
     def __call__(
         self,
@@ -50,16 +77,24 @@ class LczeroLoss:
     ) -> Tuple[jax.Array, Dict[str, jax.Array]]:
         value_pred, policy_pred, movesleft_pred = model(inputs)
 
-        unweighted_losses = {
-            "value": self.value_loss(value_pred, value_targets),
-            "policy": self.policy_loss(policy_pred, policy_targets),
-            "movesleft": self.movesleft_loss(movesleft_pred, movesleft_targets),
-        }
+        weighted_losses: List[jax.Array] = []
+        unweighted_losses: Dict[str, jax.Array] = {}
 
-        data_loss = tree_util.tree_reduce(
-            jnp.add,
-            tree_util.tree_map(jnp.multiply, self.weights, unweighted_losses),
-        )
+        def accumulate(
+            specs: Sequence[_WeightedLoss],
+            predictions: jax.Array,
+            targets: jax.Array,
+        ) -> None:
+            for spec in specs:
+                loss = spec.fn(predictions, targets)
+                unweighted_losses[spec.key] = loss
+                weighted_losses.append(spec.weight * loss)
+
+        accumulate(self._policy_losses, policy_pred, policy_targets)
+        accumulate(self._value_losses, value_pred, value_targets)
+        accumulate(self._movesleft_losses, movesleft_pred, movesleft_targets)
+
+        data_loss = jnp.sum(jnp.stack(weighted_losses, axis=0), axis=0)
 
         return data_loss, unweighted_losses
 
@@ -78,7 +113,7 @@ class ValueLoss:
         return value_cross_entropy
 
 
-class PolicyLoss:
+class PolicyCrossEntropyLoss:
     def __init__(self, config: PolicyLossWeightsConfig):
         self.config = config
 
@@ -97,6 +132,47 @@ class PolicyLoss:
         loss = optax.safe_softmax_cross_entropy(
             logits=policy_pred, labels=jax.lax.stop_gradient(policy_targets)
         )
+        assert isinstance(loss, jax.Array)
+        return loss
+
+
+class PolicyKLLoss:
+    def __init__(self, config: PolicyKLLossWeightsConfig):
+        self.config = config
+        temperature = config.temperature
+        if temperature <= 0:
+            temperature = 1.0
+        self._temperature = temperature
+
+    def __call__(
+        self,
+        policy_pred: jax.Array,
+        policy_targets: jax.Array,
+    ) -> jax.Array:
+        policy_targets = jnp.asarray(policy_targets, dtype=policy_pred.dtype)
+        if self.config.illegal_moves == PolicyLossWeightsConfig.MASK:
+            policy_pred = jnp.where(policy_targets >= 0, policy_pred, -jnp.inf)
+
+        policy_targets = jax.nn.relu(policy_targets)
+
+        if self._temperature != 1.0:
+            policy_targets = jnp.power(policy_targets, 1.0 / self._temperature)
+
+        target_sum = jnp.sum(policy_targets, axis=-1, keepdims=True)
+        safe_sum = jnp.where(
+            target_sum > 0, target_sum, jnp.ones_like(target_sum)
+        )
+        policy_targets = policy_targets / safe_sum
+
+        safe_targets = jax.lax.stop_gradient(policy_targets)
+
+        cross_entropy = optax.safe_softmax_cross_entropy(
+            logits=policy_pred, labels=safe_targets
+        )
+        target_entropy = -jnp.sum(
+            xlogy(policy_targets, policy_targets), axis=-1
+        )
+        loss = cross_entropy - target_entropy
         assert isinstance(loss, jax.Array)
         return loss
 


### PR DESCRIPTION
## Summary
- add a docstring to `_WeightedLoss` that documents the callable contract for loss builders
- simplify the accumulation to stack and sum weighted losses directly now that specs are expected to be populated

## Testing
- just format
- just pre-commit

------
https://chatgpt.com/codex/tasks/task_e_68dcdffb4f9883319ae207802749f0fe