### PR TITLE
Add optional deblunder controls to chunk rescorer config

### DIFF
--- a/csrc/loader/stages/chunk_rescorer.cc
+++ b/csrc/loader/stages/chunk_rescorer.cc
@@ -29,6 +29,11 @@ ChunkRescorer::ChunkRescorer(const ChunkRescorerConfig& config,
   static absl::once_flag bitboards_initialized_flag;
   absl::call_once(bitboards_initialized_flag, InitializeMagicBitboards);
 
+  if (config.has_deblunder_threshold() && config.has_deblunder_width()) {
+    RescorerDeblunderSetup(config.deblunder_threshold(),
+                           config.deblunder_width());
+  }
+
   LOG(INFO) << "Initializing ChunkRescorer with " << config.threads()
             << " worker thread(s) and queue capacity "
             << config.queue_capacity();

--- a/docs/example.textproto
+++ b/docs/example.textproto
@@ -42,6 +42,8 @@ data_loader {
       dist_offset: 0.0      # Policy offset applied during rescoring
       dtz_boost: 0.0        # DTZ boost for endgame policy tuning
       new_input_format: -1  # Keep original input format (-1 disables change)
+      deblunder_threshold: 0.10  # Threshold for policy deblundering adjustments
+      deblunder_width: 0.06      # Width controlling smoothing around threshold
     }
   }
   stage {

--- a/proto/data_loader_config.proto
+++ b/proto/data_loader_config.proto
@@ -62,6 +62,10 @@ message ChunkRescorerConfig {
   optional float dtz_boost = 7 [default = 0.0];
   // Optional conversion target for input format (-1 keeps original).
   optional int32 new_input_format = 8 [default = -1];
+  // Optional deblunder threshold for policy adjustments.
+  optional float deblunder_threshold = 9;
+  // Optional deblunder width controlling smoothing around the threshold.
+  optional float deblunder_width = 10;
 }
 
 // Configuration for chunk unpacker that extracts frames from packed chunks.


### PR DESCRIPTION
## Summary
- add optional deblunder threshold and width fields to `ChunkRescorerConfig`
- invoke `RescorerDeblunderSetup` when both new settings are provided
- document the new configuration knobs in the example textproto

## Testing
- `uv run meson compile -C build/release/`
- `uv run meson test -C build/release/`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68de92440d388331b0a4d2a650550f04