### PR TITLE
Add ability to start training immediately on demand

### DIFF
--- a/src/lczero_training/daemon/daemon.py
+++ b/src/lczero_training/daemon/daemon.py
@@ -10,7 +10,11 @@ import proto.training_metrics_pb2 as training_metrics_pb2
 
 from .pipeline import TrainingPipeline
 from .protocol.communicator import Communicator
-from .protocol.messages import StartTrainingPayload, TrainingStatusPayload
+from .protocol.messages import (
+    StartTrainingImmediatelyPayload,
+    StartTrainingPayload,
+    TrainingStatusPayload,
+)
 
 
 class TrainingDaemon:
@@ -119,3 +123,14 @@ class TrainingDaemon:
 
     def on_start_training(self, payload: StartTrainingPayload) -> None:
         self._config_filepath = payload.config_filepath
+
+    def on_start_training_immediately(
+        self, payload: StartTrainingImmediatelyPayload
+    ) -> None:
+        if not self._training_pipeline:
+            logging.warning(
+                "Received immediate training request before pipeline initialization."
+            )
+            return
+
+        self._training_pipeline.start_training_immediately()

--- a/src/lczero_training/daemon/protocol/messages.py
+++ b/src/lczero_training/daemon/protocol/messages.py
@@ -37,6 +37,12 @@ class StartTrainingPayload:
     config_filepath: str
 
 
+@register("start_training_immediately")
+@dataclass
+class StartTrainingImmediatelyPayload:
+    pass
+
+
 # --- Notifications from Trainer (Child) to UI (Parent) ---
 
 


### PR DESCRIPTION
## Summary
- allow the training pipeline to skip waiting for additional chunks when an immediate start is requested, while keeping the wait counter aligned with the current chunk total
- add a new daemon protocol message and handler to forward the immediate start request to the pipeline
- expose a command palette entry in the TUI that triggers the immediate training start message

## Testing
- `uv run meson test -C build/release/`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68de93a25ea48331a59ac8a847f3fb1a