### PR TITLE
Add overfit training utility

### DIFF
--- a/src/lczero_training/training/__main__.py
+++ b/src/lczero_training/training/__main__.py
@@ -4,6 +4,7 @@ from .dataloader_probe import probe_dataloader
 from .describe import describe
 from .eval import eval
 from .init import init
+from .overfit import overfit
 from .training import train
 from .tune_lr import tune_lr
 
@@ -132,6 +133,24 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
     )
     tune_lr_parser.set_defaults(func=run)
 
+    # Overfit command
+    overfit_parser = subparsers.add_parser(
+        "overfit", help="Run an overfitting test on a single batch."
+    )
+    overfit_parser.add_argument(
+        "--config",
+        type=str,
+        required=True,
+        help="Path to the training config file.",
+    )
+    overfit_parser.add_argument(
+        "--num-steps",
+        type=int,
+        required=True,
+        help="Number of training steps to run on the fixed batch.",
+    )
+    overfit_parser.set_defaults(func=run)
+
     # Describe command
     describe_parser = subparsers.add_parser(
         "describe", help="Describe a trained model."
@@ -200,6 +219,11 @@ def run(args: argparse.Namespace) -> None:
             csv_output=getattr(args, "csv_output", None),
             plot_output=getattr(args, "plot_output", None),
             num_test_batches=getattr(args, "num_test_batches", 1),
+        )
+    elif args.subcommand == "overfit":
+        overfit(
+            config_filename=args.config,
+            num_steps=args.num_steps,
         )
     elif args.subcommand == "describe":
         describe(

--- a/src/lczero_training/training/overfit.py
+++ b/src/lczero_training/training/overfit.py
@@ -97,9 +97,10 @@ def overfit(*, config_filename: str, num_steps: int) -> None:
         unweighted_host = tree_util.tree_map(
             lambda x: float(np.asarray(x)), unweighted_host
         )
+        step_value = int(np.asarray(jax.device_get(jit_state.step)).flat[0])
         logger.info(
             "Step %d: loss=%f, unweighted_losses=%s",
-            jit_state.step,
+            step_value,
             loss_value,
             unweighted_host,
         )

--- a/src/lczero_training/training/overfit.py
+++ b/src/lczero_training/training/overfit.py
@@ -1,0 +1,105 @@
+"""Overfitting utility for quickly validating training setup."""
+
+import logging
+from contextlib import suppress
+
+import jax
+import jax.numpy as jnp
+import jax.sharding as jshard
+import numpy as np
+from flax import nnx
+from google.protobuf import text_format
+from jax import tree_util
+from jax.sharding import PartitionSpec as P
+
+from lczero_training.dataloader import DataLoader, make_dataloader
+from lczero_training.model.loss_function import LczeroLoss
+from lczero_training.model.model import LczeroModel
+from lczero_training.training.optimizer import make_gradient_transformation
+from lczero_training.training.state import TrainingState
+from lczero_training.training.training import Training
+from proto.root_config_pb2 import RootConfig
+
+logger = logging.getLogger(__name__)
+
+
+def _stop_loader(loader: DataLoader) -> None:
+    with suppress(Exception):
+        loader.stop()
+
+
+def _prepare_batch(batch: tuple) -> dict:
+    inputs, policy, values, _, movesleft = batch
+    return {
+        "inputs": jnp.asarray(inputs),
+        "value_targets": jnp.asarray(values),
+        "policy_targets": jnp.asarray(policy),
+        "movesleft_targets": jnp.asarray(movesleft),
+    }
+
+
+def overfit(*, config_filename: str, num_steps: int) -> None:
+    """Runs an overfitting loop on a single batch to validate training."""
+
+    if num_steps <= 0:
+        raise ValueError("num_steps must be a positive integer")
+
+    config = RootConfig()
+    logger.info("Reading configuration from proto file")
+    with open(config_filename, "r") as config_file:
+        text_format.Parse(config_file.read(), config)
+
+    logger.info("Creating data loader and fetching a single batch")
+    loader = make_dataloader(config.data_loader)
+    try:
+        batch = loader.get_next()
+    finally:
+        _stop_loader(loader)
+
+    prepared_batch = _prepare_batch(batch)
+
+    logger.info("Creating training state from configuration")
+    training_state = TrainingState.new_from_config(
+        model_config=config.model,
+        training_config=config.training,
+    )
+
+    graphdef, _ = nnx.split(
+        LczeroModel(config=config.model, rngs=nnx.Rngs(params=42))
+    )
+
+    jit_state = training_state.jit_state
+    if jax.device_count() > 1:
+        mesh = jshard.Mesh(jax.devices(), axis_names=("batch",))
+        replicated_sharding = jshard.NamedSharding(mesh, P())
+        jit_state = jax.device_put(jit_state, replicated_sharding)
+
+    optimizer_tx = make_gradient_transformation(
+        config.training.optimizer,
+        max_grad_norm=getattr(config.training, "max_grad_norm", 0.0),
+    )
+
+    training = Training(
+        optimizer_tx=optimizer_tx,
+        graphdef=graphdef,
+        loss_fn=LczeroLoss(config=config.training.losses),
+    )
+
+    logger.info("Starting overfit loop for %d steps", num_steps)
+    for _ in range(num_steps):
+        jit_state, (loss, unweighted_losses) = training.train_step(
+            optimizer_tx,
+            jit_state,
+            prepared_batch,
+        )
+        loss_value, unweighted_host = jax.device_get((loss, unweighted_losses))
+        loss_value = float(np.asarray(loss_value))
+        unweighted_host = tree_util.tree_map(
+            lambda x: float(np.asarray(x)), unweighted_host
+        )
+        logger.info(
+            "Step %d: loss=%f, unweighted_losses=%s",
+            jit_state.step,
+            loss_value,
+            unweighted_host,
+        )


### PR DESCRIPTION
## Summary
- add an overfit helper that repeatedly trains on a single batch for debugging
- expose the helper through a new `overfit` CLI subcommand

## Testing
- uv run ruff check src/lczero_training/training/overfit.py src/lczero_training/training/__main__.py
- uv run mypy -p lczero_training --disallow-untyped-defs --disallow-incomplete-defs
- uv run meson test -C build/release/
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfd3d357dc8331affdeffe03bcfe79