### PR TITLE
Log chunk metadata when chunk rescore fails

### DIFF
--- a/csrc/loader/stages/chunk_rescorer.cc
+++ b/csrc/loader/stages/chunk_rescorer.cc
@@ -111,7 +111,11 @@ void ChunkRescorer::Worker(ThreadContext* context) {
         producer.Put(std::move(chunk));
       } catch (const std::exception& exception) {
         LOG(ERROR) << "ChunkRescorer failed to rescore chunk: "
-                   << exception.what();
+                   << exception.what() << "; sort_key=" << chunk.sort_key
+                   << "; index_within_sort_key=" << chunk.index_within_sort_key
+                   << "; global_index=" << chunk.global_index
+                   << "; reshuffle_count=" << chunk.reshuffle_count
+                   << "; frame_count=" << chunk.frames.size();
         continue;
       }
     }


### PR DESCRIPTION
## Summary
- include TrainingChunk metadata in the ChunkRescorer error log to aid debugging of rescore failures

## Testing
- `uv run mypy -p lczero_training --disallow-untyped-defs --disallow-incomplete-defs`
- `uv run meson compile -C build/release/`
- `uv run meson test -C build/release/`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e0fb59a57c8331bc606ce933809f67