### PR TITLE
Add debug chunk source for deterministic loader testing

### DIFF
--- a/csrc/loader/chunk_source/debug_chunk_source.cc
+++ b/csrc/loader/chunk_source/debug_chunk_source.cc
@@ -1,0 +1,63 @@
+#include "loader/chunk_source/debug_chunk_source.h"
+
+#include <algorithm>
+#include <cinttypes>
+#include <cmath>
+#include <cstring>
+#include <random>
+#include <utility>
+
+#include "absl/hash/hash.h"
+#include "absl/strings/str_format.h"
+
+namespace lczero {
+namespace training {
+
+DebugChunkSource::DebugChunkSource(uint64_t id, double mean_chunk_count)
+    : id_(id), mean_chunk_count_(mean_chunk_count) {}
+
+std::string DebugChunkSource::GetChunkSortKey() const {
+  return absl::StrFormat("%08" PRIu64, id_);
+}
+
+void DebugChunkSource::Index() {}
+
+size_t DebugChunkSource::GetChunkCount() const {
+  if (!cached_chunk_count_.has_value()) {
+    std::mt19937_64 rng(id_);
+    const double stddev = std::max(1.0, mean_chunk_count_ / 4.0);
+    std::normal_distribution<double> distribution(mean_chunk_count_, stddev);
+    const double sampled = distribution(rng);
+    const auto rounded =
+        static_cast<long long>(std::llround(std::max(sampled, 1.0)));
+    cached_chunk_count_ = static_cast<size_t>(rounded);
+  }
+  return *cached_chunk_count_;
+}
+
+std::optional<std::string> DebugChunkSource::GetChunkData(size_t index) {
+  const auto seed_pair = std::make_pair(id_, index);
+  const uint64_t seed = static_cast<uint64_t>(
+      absl::Hash<std::pair<uint64_t, size_t>>{}(seed_pair));
+  std::mt19937_64 rng(seed);
+  std::uniform_int_distribution<int> frame_count_distribution(1, 200);
+  const int frame_count = frame_count_distribution(rng);
+
+  const size_t bytes_per_frame = sizeof(FrameType);
+  std::string chunk(static_cast<size_t>(frame_count) * bytes_per_frame, '\0');
+  char* chunk_data = chunk.data();
+  FrameType frame{};
+  frame.planes[0] = static_cast<uint64_t>(id_);
+  frame.planes[1] = static_cast<uint64_t>(index);
+
+  for (int frame_index = 0; frame_index < frame_count; ++frame_index) {
+    frame.planes[2] = static_cast<uint64_t>(frame_index);
+    std::memcpy(chunk_data + static_cast<size_t>(frame_index) * bytes_per_frame,
+                &frame, bytes_per_frame);
+  }
+
+  return chunk;
+}
+
+}  // namespace training
+}  // namespace lczero

--- a/csrc/loader/chunk_source/debug_chunk_source.h
+++ b/csrc/loader/chunk_source/debug_chunk_source.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <random>
+#include <string>
+
+#include "loader/chunk_source/chunk_source.h"
+#include "trainingdata/trainingdata_v6.h"
+
+namespace lczero {
+namespace training {
+
+// DebugChunkSource synthesizes deterministic pseudo-random chunks for loader
+// debugging. Each instance is identified by an integer id. The class produces
+// a chunk count sampled from a normal distribution with the provided mean and
+// mean / 4 standard deviation. The id serves as the seed, which keeps the
+// number of chunks stable across runs. Individual chunks contain a
+// pseudo-random number of V6TrainingData frames (between one and 200) that are
+// generated on demand. The generation seed depends on both the source id and
+// chunk index. This lets shuffling logic exercise variable chunk sizes while
+// keeping the content reproducible. Each generated frame is zero-initialized,
+// but the first three entries of the planes array encode, respectively, the
+// source id, the chunk index, and the frame index within the chunk. This makes
+// it easy to reason about ordering and grouping when inspecting chunk payloads.
+class DebugChunkSource : public ChunkSource {
+ public:
+  using FrameType = V6TrainingData;
+
+  DebugChunkSource(uint64_t id, double mean_chunk_count);
+
+ private:
+  std::string GetChunkSortKey() const override;
+  void Index() override;
+  size_t GetChunkCount() const override;
+  std::optional<std::string> GetChunkData(size_t index) override;
+
+  uint64_t id_;
+  double mean_chunk_count_;
+  mutable std::optional<size_t> cached_chunk_count_;
+};
+
+}  // namespace training
+}  // namespace lczero

--- a/meson.build
+++ b/meson.build
@@ -119,6 +119,7 @@ files = [
   'csrc/loader/stages/chunk_unpacker.cc',
   'csrc/loader/stages/file_path_provider.cc',
   'csrc/loader/stages/stage_factory.cc',
+  'csrc/loader/chunk_source/debug_chunk_source.cc',
   'csrc/loader/chunk_source/rawfile_chunk_source.cc',
   'csrc/loader/chunk_source/tar_chunk_source.cc',
   'csrc/loader/stages/shuffling_frame_sampler.cc',


### PR DESCRIPTION
## Summary
- add a DebugChunkSource that synthesizes deterministic pseudo-random chunks for debugging
- encode the source, chunk, and frame indices in generated frame data for easy inspection
- register the new debug chunk source implementation with the build

## Testing
- uv run mypy -p lczero_training --disallow-untyped-defs --disallow-incomplete-defs
- uv run meson compile -C build/release/
- meson test -C build/release/
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0f9a1486883319bcb607dac989342