### PR TITLE
Add plies-until-progress moves-left head

### DIFF
--- a/csrc/loader/chunk_source/rawfile_chunk_source.cc
+++ b/csrc/loader/chunk_source/rawfile_chunk_source.cc
@@ -2,8 +2,10 @@
 
 #include <absl/log/log.h>
 
+#include <cstring>
 #include <fstream>
 #include <stdexcept>
+#include <type_traits>
 
 #include "trainingdata/trainingdata_v6.h"
 #include "utils/files.h"
@@ -31,28 +33,32 @@ std::optional<std::vector<FrameType>> RawFileChunkSource::GetChunkData(
   std::string data = ReadFileToString(filename_);
   if (data.empty()) return std::nullopt;
 
-  const size_t input_size =
-      frame_format_ == ChunkSourceLoaderConfig::V7TrainingData
-          ? sizeof(V7TrainingData)
-          : sizeof(V6TrainingData);
-  if (data.size() % input_size != 0) {
-    LOG(WARNING) << "File " << filename_ << " size " << data.size()
-                 << " is not a multiple of input frame size " << input_size;
-    return std::nullopt;
-  }
-
-  const size_t num_frames = data.size() / input_size;
-  std::vector<V7TrainingData> result(num_frames);
-
-  if (frame_format_ == ChunkSourceLoaderConfig::V7TrainingData) {
-    std::memcpy(result.data(), data.data(), data.size());
-  } else {
-    const auto* v6_data = reinterpret_cast<const V6TrainingData*>(data.data());
-    for (size_t i = 0; i < num_frames; ++i) {
-      std::memcpy(&result[i], &v6_data[i], sizeof(V6TrainingData));
+  // FrameType has a trailing in-memory byte; on-disk records are V6/V7 sized.
+  // Copy each record into the V6/V7 base of its FrameType slot.
+  const auto parse = [&](auto tag) -> std::optional<std::vector<FrameType>> {
+    using Record = typename decltype(tag)::type;
+    if (data.size() % sizeof(Record) != 0) {
+      LOG(WARNING) << "File " << filename_ << " size " << data.size()
+                   << " is not a multiple of input frame size "
+                   << sizeof(Record);
+      return std::nullopt;
     }
+    const size_t num_frames = data.size() / sizeof(Record);
+    const auto* records = reinterpret_cast<const Record*>(data.data());
+    std::vector<FrameType> result(num_frames);
+    for (size_t i = 0; i < num_frames; ++i) {
+      std::memcpy(static_cast<Record*>(&result[i]), &records[i],
+                  sizeof(Record));
+    }
+    return result;
+  };
+
+  switch (frame_format_) {
+    case ChunkSourceLoaderConfig::V7TrainingData:
+      return parse(std::type_identity<V7TrainingData>{});
+    default:
+      return parse(std::type_identity<V6TrainingData>{});
   }
-  return result;
 }
 
 }  // namespace training

--- a/csrc/loader/chunk_source/tar_chunk_source.cc
+++ b/csrc/loader/chunk_source/tar_chunk_source.cc
@@ -2,6 +2,8 @@
 
 #include <absl/log/log.h>
 #include <absl/strings/str_cat.h>
+#include <fcntl.h>
+#include <unistd.h>
 #include <zlib.h>
 
 #include <algorithm>
@@ -9,9 +11,8 @@
 #include <cassert>
 #include <cstdint>
 #include <cstring>
-#include <fcntl.h>
 #include <stdexcept>
-#include <unistd.h>
+#include <type_traits>
 
 #include "trainingdata/trainingdata_v6.h"
 #include "utils/gz.h"
@@ -208,30 +209,33 @@ std::optional<std::vector<FrameType>> TarChunkSource::GetChunkData(
   }
   if (content.empty()) return std::nullopt;
 
-  const size_t input_size =
-      frame_format_ == ChunkSourceLoaderConfig::V7TrainingData
-          ? sizeof(V7TrainingData)
-          : sizeof(V6TrainingData);
-  if (content.size() % input_size != 0) {
-    LOG(WARNING) << "Chunk " << index << " from " << filename_ << " size "
-                 << content.size() << " is not a multiple of input frame size "
-                 << input_size;
-    return std::nullopt;
-  }
-
-  const size_t num_frames = content.size() / input_size;
-  std::vector<V7TrainingData> result(num_frames);
-
-  if (frame_format_ == ChunkSourceLoaderConfig::V7TrainingData) {
-    std::memcpy(result.data(), content.data(), content.size());
-  } else {
-    const auto* v6_data =
-        reinterpret_cast<const V6TrainingData*>(content.data());
-    for (size_t i = 0; i < num_frames; ++i) {
-      std::memcpy(&result[i], &v6_data[i], sizeof(V6TrainingData));
+  // FrameType has a trailing in-memory byte; on-disk records are V6/V7 sized.
+  // Copy each record into the V6/V7 base of its FrameType slot.
+  const auto parse = [&](auto tag) -> std::optional<std::vector<FrameType>> {
+    using Record = typename decltype(tag)::type;
+    if (content.size() % sizeof(Record) != 0) {
+      LOG(WARNING) << "Chunk " << index << " from " << filename_ << " size "
+                   << content.size()
+                   << " is not a multiple of input frame size "
+                   << sizeof(Record);
+      return std::nullopt;
     }
+    const size_t num_frames = content.size() / sizeof(Record);
+    const auto* records = reinterpret_cast<const Record*>(content.data());
+    std::vector<FrameType> result(num_frames);
+    for (size_t i = 0; i < num_frames; ++i) {
+      std::memcpy(static_cast<Record*>(&result[i]), &records[i],
+                  sizeof(Record));
+    }
+    return result;
+  };
+
+  switch (frame_format_) {
+    case ChunkSourceLoaderConfig::V7TrainingData:
+      return parse(std::type_identity<V7TrainingData>{});
+    default:
+      return parse(std::type_identity<V6TrainingData>{});
   }
-  return result;
 }
 
 std::optional<std::string> TarChunkSource::GetChunkPrefix(size_t index,

--- a/csrc/loader/chunk_source/tar_chunk_source.cc
+++ b/csrc/loader/chunk_source/tar_chunk_source.cc
@@ -7,11 +7,9 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
-#include <cerrno>
 #include <cstdint>
 #include <cstring>
 #include <fcntl.h>
-#include <limits>
 #include <stdexcept>
 #include <unistd.h>
 
@@ -52,24 +50,12 @@ uint64_t ParseOctal(const std::array<uint8_t, 12>& octal) {
 }
 
 bool ReadExact(int fd, off_t offset, void* buffer, size_t size) {
-  if (offset < 0) return false;
-  if (size > static_cast<size_t>(std::numeric_limits<ssize_t>::max())) {
-    return false;
-  }
   char* out = static_cast<char*>(buffer);
   size_t read_total = 0;
   while (read_total < size) {
-    if (offset > std::numeric_limits<off_t>::max() -
-                     static_cast<off_t>(read_total)) {
-      return false;
-    }
     const ssize_t read_now =
         pread(fd, out + read_total, size - read_total, offset + read_total);
-    if (read_now < 0) {
-      if (errno == EINTR) continue;
-      return false;
-    }
-    if (read_now == 0) return false;
+    if (read_now <= 0) return false;
     read_total += static_cast<size_t>(read_now);
   }
   return true;
@@ -154,12 +140,10 @@ TarChunkSource::TarChunkSource(
 TarChunkSource::~TarChunkSource() { Close(); }
 
 void TarChunkSource::Close() {
-  if (fd_ >= 0) {
-    if (close(fd_) != 0) {
-      PLOG(WARNING) << "Failed to close tar file descriptor for " << path_;
-    }
-    fd_ = -1;
+  if (fd_ >= 0 && close(fd_) != 0) {
+    PLOG(WARNING) << "Failed to close tar file descriptor for " << path_;
   }
+  fd_ = -1;
 }
 
 std::string TarChunkSource::GetChunkSortKey() const { return filename_; }
@@ -193,18 +177,8 @@ void TarChunkSource::Index() {
     const std::filesystem::path filepath = std::filesystem::path(fname);
     const off_t file_offset = offset;
     const size_t size = ParseOctal(header.size);
-    const uint64_t padded_size =
-        ((static_cast<uint64_t>(size) + 511) / 512) * 512;
-    if (padded_size > static_cast<uint64_t>(std::numeric_limits<off_t>::max()) ||
-        file_offset > std::numeric_limits<off_t>::max() -
-                          static_cast<off_t>(padded_size)) {
-      LOG(WARNING) << "Truncated tar file at " << fname
-                   << ", expected size: " << size
-                   << ", actual size: 0";
-      break;
-    }
-    const off_t new_offset = file_offset + static_cast<off_t>(padded_size);
-    offset = new_offset;
+    const size_t padded_size = ((size + 511) / 512) * 512;
+    offset = file_offset + static_cast<off_t>(padded_size);
 
     if (filepath.filename() == "LICENSE") continue;
     files_.push_back({file_offset, size, filepath.extension() == ".gz"});

--- a/csrc/loader/chunk_source/tar_chunk_source.cc
+++ b/csrc/loader/chunk_source/tar_chunk_source.cc
@@ -7,8 +7,13 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <cerrno>
 #include <cstdint>
+#include <cstring>
+#include <fcntl.h>
+#include <limits>
 #include <stdexcept>
+#include <unistd.h>
 
 #include "trainingdata/trainingdata_v6.h"
 #include "utils/gz.h"
@@ -46,13 +51,33 @@ uint64_t ParseOctal(const std::array<uint8_t, 12>& octal) {
   return value;
 }
 
-std::optional<std::string> ReadGzipPrefix(FILE* file, long int offset,
-                                          long int size, size_t max_bytes) {
-  if (max_bytes == 0) return std::string();
-
-  if (fseek(file, offset, SEEK_SET) != 0) {
-    return std::nullopt;
+bool ReadExact(int fd, off_t offset, void* buffer, size_t size) {
+  if (offset < 0) return false;
+  if (size > static_cast<size_t>(std::numeric_limits<ssize_t>::max())) {
+    return false;
   }
+  char* out = static_cast<char*>(buffer);
+  size_t read_total = 0;
+  while (read_total < size) {
+    if (offset > std::numeric_limits<off_t>::max() -
+                     static_cast<off_t>(read_total)) {
+      return false;
+    }
+    const ssize_t read_now =
+        pread(fd, out + read_total, size - read_total, offset + read_total);
+    if (read_now < 0) {
+      if (errno == EINTR) continue;
+      return false;
+    }
+    if (read_now == 0) return false;
+    read_total += static_cast<size_t>(read_now);
+  }
+  return true;
+}
+
+std::optional<std::string> ReadGzipPrefix(int fd, off_t offset, size_t size,
+                                          size_t max_bytes) {
+  if (max_bytes == 0) return std::string();
 
   z_stream strm = {};
   if (inflateInit2(&strm, 16 + MAX_WBITS) != Z_OK) {
@@ -66,21 +91,21 @@ std::optional<std::string> ReadGzipPrefix(FILE* file, long int offset,
   std::string output;
   output.reserve(std::min<size_t>(max_bytes, kChunkSize));
 
-  long int remaining = size;
+  size_t remaining = size;
+  off_t current_offset = offset;
   bool finished = false;
 
   while (remaining > 0 && !finished && output.size() < max_bytes) {
-    const size_t to_read = static_cast<size_t>(
-        std::min<long int>(remaining, static_cast<long int>(kChunkSize)));
-    const size_t read = fread(input_buffer.data(), 1, to_read, file);
-    if (read != to_read) {
+    const size_t to_read = std::min(remaining, kChunkSize);
+    if (!ReadExact(fd, current_offset, input_buffer.data(), to_read)) {
       inflateEnd(&strm);
       return std::nullopt;
     }
-    remaining -= static_cast<long int>(read);
+    remaining -= to_read;
+    current_offset += static_cast<off_t>(to_read);
 
     strm.next_in = reinterpret_cast<Bytef*>(input_buffer.data());
-    strm.avail_in = static_cast<uInt>(read);
+    strm.avail_in = static_cast<uInt>(to_read);
 
     while (strm.avail_in > 0 && output.size() < max_bytes) {
       strm.next_out = reinterpret_cast<Bytef*>(output_buffer.data());
@@ -113,16 +138,28 @@ std::optional<std::string> ReadGzipPrefix(FILE* file, long int offset,
 TarChunkSource::TarChunkSource(
     const std::filesystem::path& filename,
     ChunkSourceLoaderConfig::FrameFormat frame_format)
-    : file_(fopen(filename.string().c_str(), "rb")),
+    : path_(filename),
       filename_(filename.filename().string()),
       frame_format_(frame_format) {
-  if (!file_) throw std::runtime_error("Failed to open tar file");
+  fd_ = open(path_.c_str(), O_RDONLY | O_CLOEXEC);
+  if (fd_ < 0) {
+    throw std::runtime_error(
+        absl::StrCat("Failed to open tar file: ", path_.string(), ": ",
+                     std::strerror(errno)));
+  }
   // Perform indexing during construction.
   Index();
 }
 
-TarChunkSource::~TarChunkSource() {
-  if (file_) fclose(file_);
+TarChunkSource::~TarChunkSource() { Close(); }
+
+void TarChunkSource::Close() {
+  if (fd_ >= 0) {
+    if (close(fd_) != 0) {
+      PLOG(WARNING) << "Failed to close tar file descriptor for " << path_;
+    }
+    fd_ = -1;
+  }
 }
 
 std::string TarChunkSource::GetChunkSortKey() const { return filename_; }
@@ -130,12 +167,15 @@ std::string TarChunkSource::GetChunkSortKey() const { return filename_; }
 void TarChunkSource::Index() {
   assert(files_.empty());
 
+  off_t offset = 0;
+
   while (true) {
     TarHeader header;
-    if (fread(&header, sizeof(header), 1, file_) != 1) {
+    if (!ReadExact(fd_, offset, &header, sizeof(header))) {
       LOG(WARNING) << "Truncated tar file: " << filename_;
       break;
     }
+    offset += sizeof(header);
 
     if (header.name[0] == '\0') break;  // End of file.
 
@@ -151,19 +191,23 @@ void TarChunkSource::Index() {
 
     std::string_view fname(const_cast<const char*>(header.name.data()));
     const std::filesystem::path filepath = std::filesystem::path(fname);
-    const long int offset = ftell(file_);
-    const long int size = ParseOctal(header.size);
-    const long int new_offset = offset + (size + 511) / 512 * 512;
-    fseek(file_, new_offset, SEEK_SET);
-    if (new_offset != ftell(file_)) {
+    const off_t file_offset = offset;
+    const size_t size = ParseOctal(header.size);
+    const uint64_t padded_size =
+        ((static_cast<uint64_t>(size) + 511) / 512) * 512;
+    if (padded_size > static_cast<uint64_t>(std::numeric_limits<off_t>::max()) ||
+        file_offset > std::numeric_limits<off_t>::max() -
+                          static_cast<off_t>(padded_size)) {
       LOG(WARNING) << "Truncated tar file at " << fname
                    << ", expected size: " << size
-                   << ", actual size: " << (new_offset - offset);
+                   << ", actual size: 0";
       break;
     }
+    const off_t new_offset = file_offset + static_cast<off_t>(padded_size);
+    offset = new_offset;
 
     if (filepath.filename() == "LICENSE") continue;
-    files_.push_back({offset, size, filepath.extension() == ".gz"});
+    files_.push_back({file_offset, size, filepath.extension() == ".gz"});
   }
 
   LOG(INFO) << "Read " << files_.size() << " entries from " << filename_;
@@ -178,8 +222,9 @@ std::optional<std::vector<FrameType>> TarChunkSource::GetChunkData(
   }
   const auto& file_entry = files_[index];
   std::string content(file_entry.size, '\0');
-  fseek(file_, file_entry.offset, SEEK_SET);
-  fread(content.data(), 1, file_entry.size, file_);
+  if (!ReadExact(fd_, file_entry.offset, content.data(), file_entry.size)) {
+    return std::nullopt;
+  }
   if (file_entry.is_gzip) {
     try {
       content = GunzipBuffer(content);
@@ -222,17 +267,12 @@ std::optional<std::string> TarChunkSource::GetChunkPrefix(size_t index,
   }
   const auto& file_entry = files_[index];
   if (file_entry.is_gzip) {
-    return ReadGzipPrefix(file_, file_entry.offset, file_entry.size, max_bytes);
+    return ReadGzipPrefix(fd_, file_entry.offset, file_entry.size, max_bytes);
   }
 
-  const size_t to_read =
-      std::min(static_cast<size_t>(file_entry.size), max_bytes);
+  const size_t to_read = std::min(file_entry.size, max_bytes);
   std::string content(to_read, '\0');
-  if (fseek(file_, file_entry.offset, SEEK_SET) != 0) {
-    return std::nullopt;
-  }
-  const size_t read = fread(content.data(), 1, to_read, file_);
-  if (read != to_read) {
+  if (!ReadExact(fd_, file_entry.offset, content.data(), to_read)) {
     return std::nullopt;
   }
   return content;

--- a/csrc/loader/chunk_source/tar_chunk_source.h
+++ b/csrc/loader/chunk_source/tar_chunk_source.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <sys/types.h>
+
 #include <filesystem>
 #include <string>
 #include <vector>
@@ -26,13 +28,16 @@ class TarChunkSource : public ChunkSource {
   // Performs one-time indexing during construction. Not part of the interface.
   void Index();
   struct FileEntry {
-    long int offset;
-    long int size;
+    off_t offset;
+    size_t size;
     bool is_gzip;
   };
 
-  FILE* file_ = nullptr;
+  void Close();
+
+  int fd_ = -1;
   std::vector<FileEntry> files_;
+  std::filesystem::path path_;
   std::string filename_;
   ChunkSourceLoaderConfig::FrameFormat frame_format_;
 };

--- a/csrc/loader/frame_type.h
+++ b/csrc/loader/frame_type.h
@@ -35,7 +35,7 @@ namespace lczero {
 namespace training {
 
 struct FrameType : V7TrainingData {
-  uint8_t ply_until_progress = 0xff;
+  uint8_t plies_until_progress = 0xff;
 
   FrameType() = default;
   FrameType(const V7TrainingData& v7) : V7TrainingData(v7) {}

--- a/csrc/loader/frame_type.h
+++ b/csrc/loader/frame_type.h
@@ -27,12 +27,19 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "trainingdata/trainingdata_v7.h"
 
 namespace lczero {
 namespace training {
 
-using FrameType = V7TrainingData;
+struct FrameType : V7TrainingData {
+  uint8_t ply_until_progress = 0xff;
+
+  FrameType() = default;
+  FrameType(const V7TrainingData& v7) : V7TrainingData(v7) {}
+};
 
 }  // namespace training
 }  // namespace lczero

--- a/csrc/loader/stages/chunk_rescorer.cc
+++ b/csrc/loader/stages/chunk_rescorer.cc
@@ -1,7 +1,10 @@
 #include "loader/stages/chunk_rescorer.h"
 
+#include <algorithm>
+#include <cstdint>
 #include <stdexcept>
 #include <utility>
+#include <vector>
 
 #include "absl/base/call_once.h"
 #include "absl/log/log.h"
@@ -12,7 +15,10 @@ namespace lczero {
 namespace training {
 namespace {
 
-void V6ToV7(std::span<FrameType> data, float theta = 5.0f / 6.0f) {
+// invariance_info bit 5 = game adjudicated (see trainingdata_v6.h).
+constexpr uint8_t kAdjudicationBitMask = 1u << 5;
+
+void V6ToV7(std::span<V7TrainingData> data, float theta = 5.0f / 6.0f) {
   if (data.empty()) return;
 
   const float beta = 1.0f - theta;
@@ -22,7 +28,7 @@ void V6ToV7(std::span<FrameType> data, float theta = 5.0f / 6.0f) {
 
   // Iterate backwards to calculate EMA and lookaheads in one go.
   for (size_t i = data.size(); i-- > 0;) {
-    FrameType& item = data[i];
+    V7TrainingData& item = data[i];
 
     // For Q, we operate in an alternating sign domain.
     const float sign = (i % 2 != 0) ? -1.0f : 1.0f;
@@ -50,6 +56,39 @@ void V6ToV7(std::span<FrameType> data, float theta = 5.0f / 6.0f) {
 }
 
 }  // namespace
+
+// Fills `ply_until_progress` with the number of plies until the next frame
+// (strictly after the current one) whose `rule50_count` is 0. If the chunk
+// ends without another such frame and the trailing frame is adjudicated, the
+// remaining entries are left at 0xff. If not adjudicated, the tail is filled
+// as if a virtual progress frame sat one past the end (last -> 1, ...).
+void FillPlyUntilProgress(std::span<FrameType> data) {
+  if (data.empty()) return;
+
+  const bool adjudicated =
+      (data.back().invariance_info & kAdjudicationBitMask) != 0;
+
+  const auto clamp = [](size_t plies) {
+    return static_cast<uint8_t>(std::min<size_t>(plies, 0xff));
+  };
+
+  // Plies until the next progress frame strictly to the right; 0 means none
+  // seen yet, in which case we fall back to the adjudication-based tail rule.
+  const auto ply_value = [&](size_t i, size_t distance) -> uint8_t {
+    if (distance > 0) return clamp(distance);
+    if (adjudicated) return 0xff;
+    return clamp(data.size() - i);  // Virtual progress frame past the end.
+  };
+
+  size_t distance = 0;
+  for (size_t i = data.size(); i-- > 0;) {
+    data[i].ply_until_progress = ply_value(i, distance);
+    if (data[i].rule50_count == 0)
+      distance = 1;
+    else if (distance > 0)
+      ++distance;
+  }
+}
 
 ChunkRescorer::ChunkRescorer(const ChunkRescorerConfig& config)
     : SingleInputStage<ChunkRescorerConfig, InputType>(config),
@@ -131,10 +170,18 @@ void ChunkRescorer::Worker(std::stop_token stop_token, ThreadContext* context) {
       }();
 
       try {
-        chunk.frames = RescoreTrainingData<FrameType>(
-            chunk.frames, &tablebase_, dist_temp_, dist_offset_, dtz_boost_,
-            new_input_format_);
-        if (chunk.frames.at(0).version == 6) V6ToV7(chunk.frames, st_q_theta_);
+        // RescoreTrainingData is explicit-instantiated only for V6/V7 in
+        // libs/lc0. Slice-copy chunk.frames down to V7TrainingData, rescore,
+        // then reconstruct the FrameType vector (ply_until_progress defaults
+        // to 0xff and is then filled by FillPlyUntilProgress below).
+        std::vector<V7TrainingData> v7(chunk.frames.begin(),
+                                       chunk.frames.end());
+        v7 = RescoreTrainingData<V7TrainingData>(std::move(v7), &tablebase_,
+                                                 dist_temp_, dist_offset_,
+                                                 dtz_boost_, new_input_format_);
+        if (!v7.empty() && v7.front().version == 6) V6ToV7(v7, st_q_theta_);
+        chunk.frames.assign(v7.begin(), v7.end());
+        FillPlyUntilProgress(chunk.frames);
         LoadMetricPauser pauser(context->load_metric_updater);
         producer.Put(std::move(chunk), stop_token);
       } catch (const std::exception& exception) {

--- a/csrc/loader/stages/chunk_rescorer.cc
+++ b/csrc/loader/stages/chunk_rescorer.cc
@@ -57,12 +57,12 @@ void V6ToV7(std::span<V7TrainingData> data, float theta = 5.0f / 6.0f) {
 
 }  // namespace
 
-// Fills `ply_until_progress` with the number of plies until the next frame
+// Fills `plies_until_progress` with the number of plies until the next frame
 // (strictly after the current one) whose `rule50_count` is 0. If the chunk
 // ends without another such frame and the trailing frame is adjudicated, the
 // remaining entries are left at 0xff. If not adjudicated, the tail is filled
 // as if a virtual progress frame sat one past the end (last -> 1, ...).
-void FillPlyUntilProgress(std::span<FrameType> data) {
+void FillPliesUntilProgress(std::span<FrameType> data) {
   if (data.empty()) return;
 
   const bool adjudicated =
@@ -82,7 +82,7 @@ void FillPlyUntilProgress(std::span<FrameType> data) {
 
   size_t distance = 0;
   for (size_t i = data.size(); i-- > 0;) {
-    data[i].ply_until_progress = ply_value(i, distance);
+    data[i].plies_until_progress = ply_value(i, distance);
     if (data[i].rule50_count == 0)
       distance = 1;
     else if (distance > 0)
@@ -172,8 +172,8 @@ void ChunkRescorer::Worker(std::stop_token stop_token, ThreadContext* context) {
       try {
         // RescoreTrainingData is explicit-instantiated only for V6/V7 in
         // libs/lc0. Slice-copy chunk.frames down to V7TrainingData, rescore,
-        // then reconstruct the FrameType vector (ply_until_progress defaults
-        // to 0xff and is then filled by FillPlyUntilProgress below).
+        // then reconstruct the FrameType vector (plies_until_progress defaults
+        // to 0xff and is then filled by FillPliesUntilProgress below).
         std::vector<V7TrainingData> v7(chunk.frames.begin(),
                                        chunk.frames.end());
         v7 = RescoreTrainingData<V7TrainingData>(std::move(v7), &tablebase_,
@@ -181,7 +181,7 @@ void ChunkRescorer::Worker(std::stop_token stop_token, ThreadContext* context) {
                                                  dtz_boost_, new_input_format_);
         if (!v7.empty() && v7.front().version == 6) V6ToV7(v7, st_q_theta_);
         chunk.frames.assign(v7.begin(), v7.end());
-        FillPlyUntilProgress(chunk.frames);
+        FillPliesUntilProgress(chunk.frames);
         LoadMetricPauser pauser(context->load_metric_updater);
         producer.Put(std::move(chunk), stop_token);
       } catch (const std::exception& exception) {

--- a/csrc/loader/stages/chunk_rescorer_test.cc
+++ b/csrc/loader/stages/chunk_rescorer_test.cc
@@ -1,5 +1,6 @@
 #include "loader/stages/chunk_rescorer.h"
 
+#include <span>
 #include <string>
 #include <utility>
 #include <vector>
@@ -11,6 +12,15 @@
 
 namespace lczero {
 namespace training {
+
+// Declared here rather than in chunk_rescorer.h because it is exposed only for
+// testing; the definition lives in chunk_rescorer.cc with external linkage.
+// Fills `ply_until_progress` on each frame with the number of plies until the
+// next frame (strictly after the current one) whose `rule50_count` is 0. The
+// tail is filled based on the adjudication bit (invariance_info bit 5) of the
+// last frame: adjudicated -> 0xff sentinel; otherwise behaves as if a virtual
+// progress frame sat one past the end (last -> 1, second-to-last -> 2, ...).
+void FillPlyUntilProgress(std::span<FrameType> data);
 
 namespace {
 
@@ -76,6 +86,80 @@ TEST_F(ChunkRescorerTest, HandlesInputQueueClosure) {
   EXPECT_THROW(rescorer.output_queue()->Get(), QueueClosedException);
 
   rescorer.Stop();
+}
+
+namespace {
+
+constexpr uint8_t kAdjudicatedBit = 1u << 5;
+
+std::vector<FrameType> MakeFrames(std::vector<uint8_t> rule50_counts,
+                                  bool adjudicated) {
+  std::vector<FrameType> frames(rule50_counts.size());
+  for (size_t i = 0; i < rule50_counts.size(); ++i) {
+    frames[i].rule50_count = rule50_counts[i];
+    frames[i].invariance_info = 0;
+  }
+  if (adjudicated && !frames.empty()) {
+    frames.back().invariance_info |= kAdjudicatedBit;
+  }
+  return frames;
+}
+
+std::vector<uint8_t> ExtractPpp(const std::vector<FrameType>& frames) {
+  std::vector<uint8_t> out;
+  out.reserve(frames.size());
+  for (const auto& f : frames) out.push_back(f.ply_until_progress);
+  return out;
+}
+
+}  // namespace
+
+TEST(FillPlyUntilProgressTest, MixedSequenceNotAdjudicated) {
+  // Zeros at indices 1 and 3. Last frame has no zero strictly to its right,
+  // and is not adjudicated, so it falls back to the "virtual zero" rule.
+  auto frames = MakeFrames({3, 0, 2, 0}, /*adjudicated=*/false);
+  FillPlyUntilProgress(frames);
+  EXPECT_EQ(ExtractPpp(frames), (std::vector<uint8_t>{1, 2, 1, 1}));
+}
+
+TEST(FillPlyUntilProgressTest, MixedSequenceAdjudicated) {
+  // Same sequence but adjudicated on the last frame; tail (no zero to the
+  // right of index 3) stays at the 0xff sentinel.
+  auto frames = MakeFrames({3, 0, 2, 0}, /*adjudicated=*/true);
+  FillPlyUntilProgress(frames);
+  EXPECT_EQ(ExtractPpp(frames), (std::vector<uint8_t>{1, 2, 1, 0xff}));
+}
+
+TEST(FillPlyUntilProgressTest, AllNonZeroNotAdjudicated) {
+  auto frames = MakeFrames({5, 5, 5, 5, 5}, /*adjudicated=*/false);
+  FillPlyUntilProgress(frames);
+  EXPECT_EQ(ExtractPpp(frames), (std::vector<uint8_t>{5, 4, 3, 2, 1}));
+}
+
+TEST(FillPlyUntilProgressTest, AllNonZeroAdjudicated) {
+  auto frames = MakeFrames({5, 5, 5, 5, 5}, /*adjudicated=*/true);
+  FillPlyUntilProgress(frames);
+  EXPECT_EQ(ExtractPpp(frames),
+            (std::vector<uint8_t>{0xff, 0xff, 0xff, 0xff, 0xff}));
+}
+
+TEST(FillPlyUntilProgressTest, AllNonZeroLongClampsAtFf) {
+  // Length 300, no zeros, not adjudicated. Distance from index i is N-i,
+  // clamped at 0xff.
+  auto frames = MakeFrames(std::vector<uint8_t>(300, 7),
+                           /*adjudicated=*/false);
+  FillPlyUntilProgress(frames);
+  for (size_t i = 0; i < frames.size(); ++i) {
+    const uint8_t expected =
+        static_cast<uint8_t>(std::min<size_t>(frames.size() - i, 0xff));
+    EXPECT_EQ(frames[i].ply_until_progress, expected) << "i=" << i;
+  }
+}
+
+TEST(FillPlyUntilProgressTest, EmptyChunk) {
+  std::vector<FrameType> frames;
+  FillPlyUntilProgress(frames);  // should not crash
+  EXPECT_TRUE(frames.empty());
 }
 
 }  // namespace training

--- a/csrc/loader/stages/chunk_rescorer_test.cc
+++ b/csrc/loader/stages/chunk_rescorer_test.cc
@@ -15,12 +15,12 @@ namespace training {
 
 // Declared here rather than in chunk_rescorer.h because it is exposed only for
 // testing; the definition lives in chunk_rescorer.cc with external linkage.
-// Fills `ply_until_progress` on each frame with the number of plies until the
+// Fills `plies_until_progress` on each frame with the number of plies until the
 // next frame (strictly after the current one) whose `rule50_count` is 0. The
 // tail is filled based on the adjudication bit (invariance_info bit 5) of the
 // last frame: adjudicated -> 0xff sentinel; otherwise behaves as if a virtual
 // progress frame sat one past the end (last -> 1, second-to-last -> 2, ...).
-void FillPlyUntilProgress(std::span<FrameType> data);
+void FillPliesUntilProgress(std::span<FrameType> data);
 
 namespace {
 
@@ -108,57 +108,57 @@ std::vector<FrameType> MakeFrames(std::vector<uint8_t> rule50_counts,
 std::vector<uint8_t> ExtractPpp(const std::vector<FrameType>& frames) {
   std::vector<uint8_t> out;
   out.reserve(frames.size());
-  for (const auto& f : frames) out.push_back(f.ply_until_progress);
+  for (const auto& f : frames) out.push_back(f.plies_until_progress);
   return out;
 }
 
 }  // namespace
 
-TEST(FillPlyUntilProgressTest, MixedSequenceNotAdjudicated) {
+TEST(FillPliesUntilProgressTest, MixedSequenceNotAdjudicated) {
   // Zeros at indices 1 and 3. Last frame has no zero strictly to its right,
   // and is not adjudicated, so it falls back to the "virtual zero" rule.
   auto frames = MakeFrames({3, 0, 2, 0}, /*adjudicated=*/false);
-  FillPlyUntilProgress(frames);
+  FillPliesUntilProgress(frames);
   EXPECT_EQ(ExtractPpp(frames), (std::vector<uint8_t>{1, 2, 1, 1}));
 }
 
-TEST(FillPlyUntilProgressTest, MixedSequenceAdjudicated) {
+TEST(FillPliesUntilProgressTest, MixedSequenceAdjudicated) {
   // Same sequence but adjudicated on the last frame; tail (no zero to the
   // right of index 3) stays at the 0xff sentinel.
   auto frames = MakeFrames({3, 0, 2, 0}, /*adjudicated=*/true);
-  FillPlyUntilProgress(frames);
+  FillPliesUntilProgress(frames);
   EXPECT_EQ(ExtractPpp(frames), (std::vector<uint8_t>{1, 2, 1, 0xff}));
 }
 
-TEST(FillPlyUntilProgressTest, AllNonZeroNotAdjudicated) {
+TEST(FillPliesUntilProgressTest, AllNonZeroNotAdjudicated) {
   auto frames = MakeFrames({5, 5, 5, 5, 5}, /*adjudicated=*/false);
-  FillPlyUntilProgress(frames);
+  FillPliesUntilProgress(frames);
   EXPECT_EQ(ExtractPpp(frames), (std::vector<uint8_t>{5, 4, 3, 2, 1}));
 }
 
-TEST(FillPlyUntilProgressTest, AllNonZeroAdjudicated) {
+TEST(FillPliesUntilProgressTest, AllNonZeroAdjudicated) {
   auto frames = MakeFrames({5, 5, 5, 5, 5}, /*adjudicated=*/true);
-  FillPlyUntilProgress(frames);
+  FillPliesUntilProgress(frames);
   EXPECT_EQ(ExtractPpp(frames),
             (std::vector<uint8_t>{0xff, 0xff, 0xff, 0xff, 0xff}));
 }
 
-TEST(FillPlyUntilProgressTest, AllNonZeroLongClampsAtFf) {
+TEST(FillPliesUntilProgressTest, AllNonZeroLongClampsAtFf) {
   // Length 300, no zeros, not adjudicated. Distance from index i is N-i,
   // clamped at 0xff.
   auto frames = MakeFrames(std::vector<uint8_t>(300, 7),
                            /*adjudicated=*/false);
-  FillPlyUntilProgress(frames);
+  FillPliesUntilProgress(frames);
   for (size_t i = 0; i < frames.size(); ++i) {
     const uint8_t expected =
         static_cast<uint8_t>(std::min<size_t>(frames.size() - i, 0xff));
-    EXPECT_EQ(frames[i].ply_until_progress, expected) << "i=" << i;
+    EXPECT_EQ(frames[i].plies_until_progress, expected) << "i=" << i;
   }
 }
 
-TEST(FillPlyUntilProgressTest, EmptyChunk) {
+TEST(FillPliesUntilProgressTest, EmptyChunk) {
   std::vector<FrameType> frames;
-  FillPlyUntilProgress(frames);  // should not crash
+  FillPliesUntilProgress(frames);  // should not crash
   EXPECT_TRUE(frames.empty());
 }
 

--- a/csrc/loader/stages/shuffling_chunk_pool.cc
+++ b/csrc/loader/stages/shuffling_chunk_pool.cc
@@ -423,7 +423,8 @@ void ShufflingChunkPool::CachingWorker(std::stop_token stop_token,
 
         source_item = *it;
         max_weight = max_weight_;
-        local_index = cache_request.global_index - source_item->start_chunk_index;
+        local_index =
+            cache_request.global_index - source_item->start_chunk_index;
       }
 
       absl::MutexLock item_lock(&source_item->mutex);
@@ -498,12 +499,14 @@ ShufflingChunkPool::GetNextChunkData() {
     {
       absl::MutexLock lock(&chunk_data.source_item->mutex);
 
-      assert(chunk_data.source_item->use_counts.size() > chunk_data.local_index);
+      assert(chunk_data.source_item->use_counts.size() >
+             chunk_data.local_index);
       chunk_data.use_count =
           chunk_data.source_item->use_counts[chunk_data.local_index]++;
 
       if (cachehit_output_queue_.has_value()) {
-        auto& cache_chain = chunk_data.source_item->cache[chunk_data.local_index];
+        auto& cache_chain =
+            chunk_data.source_item->cache[chunk_data.local_index];
         if (cache_chain) {
           cache_hits_.fetch_add(1, std::memory_order_acq_rel);
           cached_positions_.fetch_sub(1, std::memory_order_acq_rel);
@@ -563,13 +566,11 @@ ShufflingChunkPool::ChunkStatus ShufflingChunkPool::GetChunkInfo(
 
     if (!chunk_index) return ChunkStatus::kEnd;
 
-    auto it =
-        absl::c_lower_bound(chunk_sources_, *chunk_index,
-                            [](const auto& item, size_t chunk_idx) {
-                              return item->start_chunk_index +
-                                         item->source->GetChunkCount() <=
-                                     chunk_idx;
-                            });
+    auto it = absl::c_lower_bound(
+        chunk_sources_, *chunk_index, [](const auto& item, size_t chunk_idx) {
+          return item->start_chunk_index + item->source->GetChunkCount() <=
+                 chunk_idx;
+        });
 
     if (ABSL_PREDICT_FALSE(it == chunk_sources_.end() ||
                            *chunk_index < (*it)->start_chunk_index)) {
@@ -671,10 +672,8 @@ void ShufflingChunkPool::AddNewChunkSource(std::unique_ptr<ChunkSource> source)
   item->source = std::move(source);
   item->use_counts = std::vector<uint16_t>(count, 0);
   item->weight = std::vector<float>(count, -1.0f);
-  item->cache =
-      std::vector<std::unique_ptr<CacheNode>>(cachehit_output_queue_.has_value()
-                                                  ? count
-                                                  : 0);
+  item->cache = std::vector<std::unique_ptr<CacheNode>>(
+      cachehit_output_queue_.has_value() ? count : 0);
   chunk_sources_.push_back(std::move(item));
 
   // Calculate current window bounds.

--- a/csrc/loader/stages/shuffling_chunk_pool.cc
+++ b/csrc/loader/stages/shuffling_chunk_pool.cc
@@ -265,22 +265,22 @@ void ShufflingChunkPool::ProcessInputFiles(
     std::for_each(uninitialized_sources.rbegin(), uninitialized_sources.rend(),
                   [this, &start_chunk_index](auto& source) {
                     const size_t count = source->GetChunkCount();
-                    chunk_sources_.push_back(
-                        {.start_chunk_index = start_chunk_index,
-                         .source = std::move(source),
-                         .dropped_chunks = {},
-                         .use_counts = std::vector<uint16_t>(count, 0),
-                         .weight = std::vector<float>(count, -1.0f),
-                         .cache = std::vector<std::unique_ptr<CacheNode>>(
-                             cachehit_output_queue_.has_value() ? count : 0)});
+                    auto item = std::make_shared<ChunkSourceItem>();
+                    item->start_chunk_index = start_chunk_index;
+                    item->source = std::move(source);
+                    item->use_counts = std::vector<uint16_t>(count, 0);
+                    item->weight = std::vector<float>(count, -1.0f);
+                    item->cache = std::vector<std::unique_ptr<CacheNode>>(
+                        cachehit_output_queue_.has_value() ? count : 0);
+                    chunk_sources_.push_back(std::move(item));
                     start_chunk_index +=
-                        chunk_sources_.back().source->GetChunkCount();
+                        chunk_sources_.back()->source->GetChunkCount();
                   });
 
     // Initialize stream shuffler with the initial bounds.
     if (!chunk_sources_.empty()) {
-      size_t total_chunks = chunk_sources_.back().start_chunk_index +
-                            chunk_sources_.back().source->GetChunkCount();
+      size_t total_chunks = chunk_sources_.back()->start_chunk_index +
+                            chunk_sources_.back()->source->GetChunkCount();
       // Set bounds to provide the last chunk_pool_size_ chunks.
       size_t lower_bound =
           total_chunks > chunk_pool_size_ ? total_chunks - chunk_pool_size_ : 0;
@@ -301,10 +301,10 @@ void ShufflingChunkPool::ProcessInputFiles(
     LOG(INFO) << "Current anchor: '" << anchor_ << "'";
 
     absl::MutexLock sources_lock(&chunk_sources_mutex_);
-    std::vector<const ChunkSourceItem*> sources_after_anchor;
+    std::vector<std::shared_ptr<ChunkSourceItem>> sources_after_anchor;
     for (const auto& item : chunk_sources_) {
-      if (item.source->GetChunkSortKey() > anchor_) {
-        sources_after_anchor.push_back(&item);
+      if (item->source->GetChunkSortKey() > anchor_) {
+        sources_after_anchor.push_back(item);
       }
     }
 
@@ -401,37 +401,44 @@ void ShufflingChunkPool::CachingWorker(std::stop_token stop_token,
         return cache_request_queue_->Get(stop_token);
       }();
 
-      absl::MutexLock lock(&chunk_sources_mutex_);
+      std::shared_ptr<ChunkSourceItem> source_item;
+      float max_weight = 0.0f;
+      size_t local_index = 0;
+      {
+        absl::MutexLock lock(&chunk_sources_mutex_);
 
-      // Find the chunk source containing this global index.
-      auto it = absl::c_lower_bound(
-          chunk_sources_, cache_request.global_index,
-          [](const auto& source_item, size_t chunk_idx) {
-            return source_item.start_chunk_index +
-                       source_item.source->GetChunkCount() <=
-                   chunk_idx;
-          });
+        // Find the chunk source containing this global index.
+        auto it = absl::c_lower_bound(
+            chunk_sources_, cache_request.global_index,
+            [](const auto& item, size_t chunk_idx) {
+              return item->start_chunk_index + item->source->GetChunkCount() <=
+                     chunk_idx;
+            });
 
-      if (it == chunk_sources_.end() ||
-          cache_request.global_index < it->start_chunk_index) {
-        chunk_source_not_found_.fetch_add(1, std::memory_order_acq_rel);
-        continue;
+        if (it == chunk_sources_.end() ||
+            cache_request.global_index < (*it)->start_chunk_index) {
+          chunk_source_not_found_.fetch_add(1, std::memory_order_acq_rel);
+          continue;
+        }
+
+        source_item = *it;
+        max_weight = max_weight_;
+        local_index = cache_request.global_index - source_item->start_chunk_index;
       }
 
-      const size_t local_index =
-          cache_request.global_index - it->start_chunk_index;
-      assert(local_index < it->use_counts.size());
+      absl::MutexLock item_lock(&source_item->mutex);
+      assert(local_index < source_item->use_counts.size());
 
       // Check use_count match.
-      if (it->use_counts[local_index] != cache_request.next_use) {
+      if (source_item->use_counts[local_index] != cache_request.next_use) {
         mismatched_use_counts_.fetch_add(1, std::memory_order_acq_rel);
         continue;
       }
 
       // Compute how many positions to cache.
-      const float weight = it->weight[local_index];
+      const float weight = source_item->weight[local_index];
       assert(weight >= 0.0f);
-      const double probability = ComputeHanseProbability(weight);
+      const double probability = ComputeHanseProbability(weight, max_weight);
       exponential_avg_probability =
           exponential_avg_probability * (1.0 - kTheta) + probability * kTheta;
       const double n = (probability * config_.position_cache_size() /
@@ -440,7 +447,7 @@ void ShufflingChunkPool::CachingWorker(std::stop_token stop_token,
       reminder = n - std::floor(n);
       const size_t positions_to_cache = static_cast<size_t>(std::floor(n));
       // Traverse and extend the cache chain.
-      std::unique_ptr<CacheNode>* current = &it->cache[local_index];
+      std::unique_ptr<CacheNode>* current = &source_item->cache[local_index];
       for (size_t i = 0; i < positions_to_cache; ++i) {
         if (*current) {
           current = &(*current)->next;
@@ -474,33 +481,29 @@ struct ShufflingChunkPool::ChunkData {
   size_t local_index = 0;
   size_t global_index = 0;
   uint32_t use_count = 0;
-  ChunkSourceItem* source_item = nullptr;
+  std::shared_ptr<ChunkSourceItem> source_item;
 };
 
 std::optional<std::variant<TrainingChunk, FrameType>>
 ShufflingChunkPool::GetNextChunkData() {
   while (true) {
     ChunkData chunk_data;
-    ChunkStatus status;
+    const ChunkStatus status = GetChunkInfo(chunk_data);
+    if (status == ChunkStatus::kEnd) return std::nullopt;
+    if (status == ChunkStatus::kRetry) continue;
+
+    const bool hanse_enabled = config_.hanse_sampling_threshold() > 0;
+    if (hanse_enabled && !HanseAccept(chunk_data)) continue;
+
     {
-      absl::MutexLock lock(&chunk_sources_mutex_);
-      status = GetChunkInfo(chunk_data);
-      if (status == ChunkStatus::kEnd) return std::nullopt;
-      if (status == ChunkStatus::kRetry) continue;
+      absl::MutexLock lock(&chunk_data.source_item->mutex);
 
-      const bool hanse_enabled = config_.hanse_sampling_threshold() > 0;
-      if (hanse_enabled && !HanseAccept(chunk_data)) continue;
-
-      // Increment use_count for this chunk.
-      assert(chunk_data.source_item->use_counts.size() >
-             chunk_data.local_index);
+      assert(chunk_data.source_item->use_counts.size() > chunk_data.local_index);
       chunk_data.use_count =
           chunk_data.source_item->use_counts[chunk_data.local_index]++;
 
-      // Check cache if configured.
       if (cachehit_output_queue_.has_value()) {
-        auto& cache_chain =
-            chunk_data.source_item->cache[chunk_data.local_index];
+        auto& cache_chain = chunk_data.source_item->cache[chunk_data.local_index];
         if (cache_chain) {
           cache_hits_.fetch_add(1, std::memory_order_acq_rel);
           cached_positions_.fetch_sub(1, std::memory_order_acq_rel);
@@ -510,11 +513,9 @@ ShufflingChunkPool::GetNextChunkData() {
         }
         cache_misses_.fetch_add(1, std::memory_order_acq_rel);
       }
-
-      if (chunk_data.data.empty()) {
-        if (!LoadChunkData(chunk_data)) continue;
-      }
     }
+
+    if (chunk_data.data.empty() && !LoadChunkData(chunk_data)) continue;
 
     TrainingChunk chunk;
     chunk.sort_key = std::move(chunk_data.sort_key);
@@ -532,6 +533,7 @@ bool ShufflingChunkPool::LoadChunkData(ChunkData& chunk_data) {
       chunk_data.source_item->source->GetChunkData(chunk_data.local_index);
 
   if (!data || data->empty()) {
+    absl::MutexLock lock(&chunk_data.source_item->mutex);
     chunk_data.source_item->dropped_chunks.insert(chunk_data.local_index);
     dropped_chunks_metric_.fetch_add(1, std::memory_order_acq_rel);
     return false;
@@ -543,55 +545,64 @@ bool ShufflingChunkPool::LoadChunkData(ChunkData& chunk_data) {
 
 ShufflingChunkPool::ChunkStatus ShufflingChunkPool::GetChunkInfo(
     ChunkData& out_chunk_data) {
-  std::optional<size_t> chunk_index = stream_shuffler_.GetNextItem();
+  std::shared_ptr<ChunkSourceItem> source_item;
+  {
+    absl::MutexLock lock(&chunk_sources_mutex_);
+    std::optional<size_t> chunk_index = stream_shuffler_.GetNextItem();
 
-  if (!chunk_index && !chunk_sources_.empty()) {
-    size_t total_chunks = chunk_sources_.back().start_chunk_index +
-                          chunk_sources_.back().source->GetChunkCount();
-    size_t lower_bound = total_chunks > chunk_pool_size_
-                             ? total_chunks - chunk_pool_size_
-                             : chunk_sources_.front().start_chunk_index;
-    stream_shuffler_.Reset(lower_bound, total_chunks);
-    reshuffles_.fetch_add(1, std::memory_order_acq_rel);
-    chunk_index = stream_shuffler_.GetNextItem();
+    if (!chunk_index && !chunk_sources_.empty()) {
+      size_t total_chunks = chunk_sources_.back()->start_chunk_index +
+                            chunk_sources_.back()->source->GetChunkCount();
+      size_t lower_bound = total_chunks > chunk_pool_size_
+                               ? total_chunks - chunk_pool_size_
+                               : chunk_sources_.front()->start_chunk_index;
+      stream_shuffler_.Reset(lower_bound, total_chunks);
+      reshuffles_.fetch_add(1, std::memory_order_acq_rel);
+      chunk_index = stream_shuffler_.GetNextItem();
+    }
+
+    if (!chunk_index) return ChunkStatus::kEnd;
+
+    auto it =
+        absl::c_lower_bound(chunk_sources_, *chunk_index,
+                            [](const auto& item, size_t chunk_idx) {
+                              return item->start_chunk_index +
+                                         item->source->GetChunkCount() <=
+                                     chunk_idx;
+                            });
+
+    if (ABSL_PREDICT_FALSE(it == chunk_sources_.end() ||
+                           *chunk_index < (*it)->start_chunk_index)) {
+      LOG(WARNING) << "Chunk index " << *chunk_index
+                   << " out of range for available chunk sources.";
+      return ChunkStatus::kRetry;
+    }
+
+    source_item = *it;
+    out_chunk_data.local_index = *chunk_index - source_item->start_chunk_index;
+    out_chunk_data.sort_key = source_item->source->GetChunkSortKey();
+    out_chunk_data.global_index = *chunk_index;
   }
 
-  if (!chunk_index) return ChunkStatus::kEnd;
-
-  auto it =
-      absl::c_lower_bound(chunk_sources_, *chunk_index,
-                          [](const auto& source_item, size_t chunk_idx) {
-                            return source_item.start_chunk_index +
-                                       source_item.source->GetChunkCount() <=
-                                   chunk_idx;
-                          });
-
-  if (ABSL_PREDICT_FALSE(it == chunk_sources_.end() ||
-                         *chunk_index < it->start_chunk_index)) {
-    LOG(WARNING) << "Chunk index " << *chunk_index
-                 << " out of range for available chunk sources.";
-    return ChunkStatus::kRetry;
+  {
+    absl::MutexLock lock(&source_item->mutex);
+    if (source_item->dropped_chunks.contains(out_chunk_data.local_index)) {
+      return ChunkStatus::kRetry;
+    }
   }
 
-  out_chunk_data.local_index = *chunk_index - it->start_chunk_index;
-  if (it->dropped_chunks.contains(out_chunk_data.local_index)) {
-    return ChunkStatus::kRetry;
-  }
-
-  out_chunk_data.source_item = &(*it);
-  out_chunk_data.sort_key = it->source->GetChunkSortKey();
-  out_chunk_data.global_index = *chunk_index;
-
+  out_chunk_data.source_item = std::move(source_item);
   return ChunkStatus::kOk;
 }
 
-double ShufflingChunkPool::ComputeHanseProbability(float weight) {
-  if (max_weight_ <= 0.0f) return 1.0;
-  return std::pow(weight / max_weight_, config_.hanse_sampling_gamma());
+double ShufflingChunkPool::ComputeHanseProbability(float weight,
+                                                   float max_weight) const {
+  if (max_weight <= 0.0f) return 1.0;
+  return std::pow(weight / max_weight, config_.hanse_sampling_gamma());
 }
 
 float ShufflingChunkPool::ComputeChunkWeight(
-    absl::Span<const FrameType> frames) {
+    absl::Span<const FrameType> frames) const {
   return absl::c_accumulate(frames, 0.0f, [this](float sum, const auto& frame) {
     return sum +
            ComputePositionSamplingWeight(frame, config_.position_sampling());
@@ -600,21 +611,42 @@ float ShufflingChunkPool::ComputeChunkWeight(
 
 bool ShufflingChunkPool::HanseAccept(ChunkData& chunk_data) {
   assert(chunk_data.source_item);
-  assert(chunk_data.source_item->weight.size() > chunk_data.local_index);
+  float weight = -1.0f;
+  {
+    absl::MutexLock lock(&chunk_data.source_item->mutex);
+    assert(chunk_data.source_item->weight.size() > chunk_data.local_index);
+    weight = chunk_data.source_item->weight[chunk_data.local_index];
+  }
 
-  if (chunk_data.source_item->weight[chunk_data.local_index] < 0.0f) {
+  if (weight < 0.0f) {
+    if (chunk_data.data.empty() && !LoadChunkData(chunk_data)) return false;
+    weight = ComputeChunkWeight(chunk_data.data);
+    {
+      absl::MutexLock pool_lock(&chunk_sources_mutex_);
+      max_weight_ = std::max(max_weight_, weight);
+      AddSample(chunk_weight_stats_, static_cast<double>(weight));
+    }
+    {
+      absl::MutexLock lock(&chunk_data.source_item->mutex);
+      const float cached_weight =
+          chunk_data.source_item->weight[chunk_data.local_index];
+      if (cached_weight < 0.0f) {
+        chunk_data.source_item->weight[chunk_data.local_index] = weight;
+      } else {
+        weight = cached_weight;
+      }
+    }
     hanse_cache_misses_.fetch_add(1, std::memory_order_acq_rel);
-    if (!LoadChunkData(chunk_data)) return false;
-    const float weight = ComputeChunkWeight(chunk_data.data);
-    chunk_data.source_item->weight[chunk_data.local_index] = weight;
-    max_weight_ = std::max(max_weight_, weight);
-    AddSample(chunk_weight_stats_, static_cast<double>(weight));
   } else {
     hanse_cache_hits_.fetch_add(1, std::memory_order_acq_rel);
   }
 
-  const double p = ComputeHanseProbability(
-      chunk_data.source_item->weight[chunk_data.local_index]);
+  float max_weight = 0.0f;
+  {
+    absl::MutexLock lock(&chunk_sources_mutex_);
+    max_weight = max_weight_;
+  }
+  const double p = ComputeHanseProbability(weight, max_weight);
   const double u = absl::Uniform<double>(bitgen_, 0.0, 1.0);
   if (u >= p) {
     hanse_rejected_.fetch_add(1, std::memory_order_acq_rel);
@@ -630,27 +662,29 @@ void ShufflingChunkPool::AddNewChunkSource(std::unique_ptr<ChunkSource> source)
   if (!chunk_sources_.empty()) {
     const auto& last_source = chunk_sources_.back();
     old_upper_bound =
-        last_source.start_chunk_index + last_source.source->GetChunkCount();
+        last_source->start_chunk_index + last_source->source->GetChunkCount();
   }
 
   size_t count = source->GetChunkCount();
-  chunk_sources_.push_back(
-      {.start_chunk_index = old_upper_bound,
-       .source = std::move(source),
-       .dropped_chunks = {},
-       .use_counts = std::vector<uint16_t>(count, 0),
-       .weight = std::vector<float>(count, -1.0f),
-       .cache = std::vector<std::unique_ptr<CacheNode>>(
-           cachehit_output_queue_.has_value() ? count : 0)});
+  auto item = std::make_shared<ChunkSourceItem>();
+  item->start_chunk_index = old_upper_bound;
+  item->source = std::move(source);
+  item->use_counts = std::vector<uint16_t>(count, 0);
+  item->weight = std::vector<float>(count, -1.0f);
+  item->cache =
+      std::vector<std::unique_ptr<CacheNode>>(cachehit_output_queue_.has_value()
+                                                  ? count
+                                                  : 0);
+  chunk_sources_.push_back(std::move(item));
 
   // Calculate current window bounds.
-  size_t new_upper_bound = chunk_sources_.back().start_chunk_index +
-                           chunk_sources_.back().source->GetChunkCount();
+  size_t new_upper_bound = chunk_sources_.back()->start_chunk_index +
+                           chunk_sources_.back()->source->GetChunkCount();
 
   // Remove old chunks if window exceeds chunk_pool_size_.
   while (!chunk_sources_.empty() && chunk_sources_.size() > 1) {
-    size_t window_start = chunk_sources_.front().start_chunk_index +
-                          chunk_sources_.front().source->GetChunkCount();
+    size_t window_start = chunk_sources_.front()->start_chunk_index +
+                          chunk_sources_.front()->source->GetChunkCount();
     size_t window_size = new_upper_bound - window_start;
 
     if (window_size < chunk_pool_size_) break;
@@ -658,7 +692,8 @@ void ShufflingChunkPool::AddNewChunkSource(std::unique_ptr<ChunkSource> source)
     // Count cached positions in the evicted source.
     if (cachehit_output_queue_.has_value()) {
       size_t evicted_cached = 0;
-      for (const auto& cache_chain : chunk_sources_.front().cache) {
+      absl::MutexLock item_lock(&chunk_sources_.front()->mutex);
+      for (const auto& cache_chain : chunk_sources_.front()->cache) {
         const CacheNode* node = cache_chain.get();
         while (node) {
           ++evicted_cached;
@@ -673,7 +708,7 @@ void ShufflingChunkPool::AddNewChunkSource(std::unique_ptr<ChunkSource> source)
   }
 
   // Update stream shuffler bounds with the sliding window.
-  size_t window_start = chunk_sources_.front().start_chunk_index;
+  size_t window_start = chunk_sources_.front()->start_chunk_index;
   size_t new_lower_bound = new_upper_bound > chunk_pool_size_
                                ? new_upper_bound - chunk_pool_size_
                                : window_start;
@@ -712,8 +747,8 @@ StageMetricProto ShufflingChunkPool::FlushMetrics() {
     if (!chunk_sources_.empty()) {
       const auto& first = chunk_sources_.front();
       const auto& last = chunk_sources_.back();
-      upper = last.start_chunk_index + last.source->GetChunkCount();
-      current = upper - first.start_chunk_index;
+      upper = last->start_chunk_index + last->source->GetChunkCount();
+      current = upper - first->start_chunk_index;
     }
 
     auto* current_chunks_metric = stage_metric.add_gauge_metrics();
@@ -832,7 +867,7 @@ std::pair<std::string, int> ShufflingChunkPool::ResetAnchor() {
     return {anchor_, previous_count};
   }
 
-  anchor_ = chunk_sources_.back().source->GetChunkSortKey();
+  anchor_ = chunk_sources_.back()->source->GetChunkSortKey();
   int previous_count = chunks_since_anchor_.exchange(0);
   return {anchor_, previous_count};
 }

--- a/csrc/loader/stages/shuffling_chunk_pool.h
+++ b/csrc/loader/stages/shuffling_chunk_pool.h
@@ -62,13 +62,14 @@ class ShufflingChunkPool : public Stage {
   };
 
   struct ChunkSourceItem {
+    mutable absl::Mutex mutex;
     size_t start_chunk_index;
     std::unique_ptr<ChunkSource> source;
-    absl::flat_hash_set<size_t> dropped_chunks;
+    absl::flat_hash_set<size_t> dropped_chunks ABSL_GUARDED_BY(mutex);
     // Per-chunk counters and cached weights.
-    std::vector<uint16_t> use_counts;
-    std::vector<float> weight;
-    std::vector<std::unique_ptr<CacheNode>> cache;
+    std::vector<uint16_t> use_counts ABSL_GUARDED_BY(mutex);
+    std::vector<float> weight ABSL_GUARDED_BY(mutex);
+    std::vector<std::unique_ptr<CacheNode>> cache ABSL_GUARDED_BY(mutex);
   };
 
   struct SourceIngestionThreadContext {
@@ -93,20 +94,16 @@ class ShufflingChunkPool : public Stage {
   void CachingWorker(std::stop_token stop_token, CachingThreadContext* context);
   void AddNewChunkSource(std::unique_ptr<ChunkSource> source)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(chunk_sources_mutex_);
-  std::optional<std::variant<TrainingChunk, FrameType>> GetNextChunkData()
-      ABSL_LOCKS_EXCLUDED(chunk_sources_mutex_);
+  std::optional<std::variant<TrainingChunk, FrameType>> GetNextChunkData();
 
   enum class ChunkStatus { kOk, kRetry, kEnd };
   struct ChunkData;
 
-  ChunkStatus GetChunkInfo(ChunkData& out_chunk_data)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(chunk_sources_mutex_);
-  bool LoadChunkData(ChunkData& chunk_data)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(chunk_sources_mutex_);
-  bool HanseAccept(ChunkData& chunk_data)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(chunk_sources_mutex_);
-  float ComputeChunkWeight(absl::Span<const FrameType> frames);
-  double ComputeHanseProbability(float weight);
+  ChunkStatus GetChunkInfo(ChunkData& out_chunk_data);
+  bool LoadChunkData(ChunkData& chunk_data);
+  bool HanseAccept(ChunkData& chunk_data);
+  float ComputeChunkWeight(absl::Span<const FrameType> frames) const;
+  double ComputeHanseProbability(float weight, float max_weight) const;
 
   Queue<ChunkSourceWithPhase>* primary_input_queue_ = nullptr;
   Queue<CacheRequest>* cache_request_queue_ = nullptr;
@@ -126,7 +123,7 @@ class ShufflingChunkPool : public Stage {
   std::atomic<int64_t> dropped_chunks_metric_{0};
 
   absl::Mutex chunk_sources_mutex_;
-  std::deque<ChunkSourceItem> chunk_sources_
+  std::deque<std::shared_ptr<ChunkSourceItem>> chunk_sources_
       ABSL_GUARDED_BY(chunk_sources_mutex_);
   StreamShuffler stream_shuffler_ ABSL_GUARDED_BY(chunk_sources_mutex_);
   float max_weight_ ABSL_GUARDED_BY(chunk_sources_mutex_) = 0.0f;

--- a/csrc/loader/stages/tensor_generator.cc
+++ b/csrc/loader/stages/tensor_generator.cc
@@ -88,7 +88,7 @@ TensorTuple TensorGenerator::ConvertFramesToTensors(
   constexpr size_t kNumPlanes = 112;
   constexpr size_t kNumPolicyMoves = 1858;
   constexpr size_t kNumValueTypes = 6;
-  constexpr size_t kValuesPerType = 3;
+  constexpr size_t kValuesPerType = 4;
 
   TensorTuple result;
   result.reserve(3);
@@ -109,8 +109,12 @@ TensorTuple TensorGenerator::ConvertFramesToTensors(
   }
   result.push_back(std::move(probs_tensor));
 
-  // Index 2: Values (batch_size, 6, 3) with [q, d, m] for each type.
-  // [0]: result, [1]: best, [2]: played, [3]: orig, [4]: root, [5]: st
+  // Index 2: Values (batch_size, 6, 4) with [q, d, m, p] for each type.
+  // [0]: result, [1]: best, [2]: played, [3]: orig, [4]: root, [5]: st.
+  // Component 3 (p) holds plies_until_progress for the result row only (0xff,
+  // i.e. unknown, maps to NaN); it is NaN for all other rows. NaN targets are
+  // masked out by the loss.
+  constexpr float kNaN = std::numeric_limits<float>::quiet_NaN();
   auto values_tensor =
       std::make_unique<TypedTensor<float>>(std::initializer_list<size_t>{
           batch_size, kNumValueTypes, kValuesPerType});
@@ -118,41 +122,49 @@ TensorTuple TensorGenerator::ConvertFramesToTensors(
     const auto& frame = frames[i];
     auto batch_slice = values_tensor->slice({static_cast<ssize_t>(i)});
 
-    // Index 0: result [result_q, result_d, plies_left]
+    // Index 0: result [result_q, result_d, plies_left, plies_until_progress]
     auto result_slice = batch_slice.subspan(0 * kValuesPerType, kValuesPerType);
     result_slice[0] = frame.result_q;
     result_slice[1] = frame.result_d;
     result_slice[2] = frame.plies_left;
+    result_slice[3] = frame.plies_until_progress == 0xff
+                          ? kNaN
+                          : static_cast<float>(frame.plies_until_progress);
 
-    // Index 1: best [best_q, best_d, best_m]
+    // Index 1: best [best_q, best_d, best_m, NaN]
     auto best_slice = batch_slice.subspan(1 * kValuesPerType, kValuesPerType);
     best_slice[0] = frame.best_q;
     best_slice[1] = frame.best_d;
     best_slice[2] = frame.best_m;
+    best_slice[3] = kNaN;
 
-    // Index 2: played [played_q, played_d, played_m]
+    // Index 2: played [played_q, played_d, played_m, NaN]
     auto played_slice = batch_slice.subspan(2 * kValuesPerType, kValuesPerType);
     played_slice[0] = frame.played_q;
     played_slice[1] = frame.played_d;
     played_slice[2] = frame.played_m;
+    played_slice[3] = kNaN;
 
-    // Index 3: orig [orig_q, orig_d, orig_m] (may be NaN)
+    // Index 3: orig [orig_q, orig_d, orig_m, NaN] (q/d/m may be NaN)
     auto orig_slice = batch_slice.subspan(3 * kValuesPerType, kValuesPerType);
     orig_slice[0] = frame.orig_q;
     orig_slice[1] = frame.orig_d;
     orig_slice[2] = frame.orig_m;
+    orig_slice[3] = kNaN;
 
-    // Index 4: root [root_q, root_d, root_m]
+    // Index 4: root [root_q, root_d, root_m, NaN]
     auto root_slice = batch_slice.subspan(4 * kValuesPerType, kValuesPerType);
     root_slice[0] = frame.root_q;
     root_slice[1] = frame.root_d;
     root_slice[2] = frame.root_m;
+    root_slice[3] = kNaN;
 
-    // Index 5: st [q_st, d_st, NaN]
+    // Index 5: st [q_st, d_st, NaN, NaN]
     auto st_slice = batch_slice.subspan(5 * kValuesPerType, kValuesPerType);
     st_slice[0] = frame.q_st;
     st_slice[1] = frame.d_st;
-    st_slice[2] = std::numeric_limits<float>::quiet_NaN();
+    st_slice[2] = kNaN;
+    st_slice[3] = kNaN;
   }
   result.push_back(std::move(values_tensor));
 

--- a/csrc/loader/stages/tensor_generator_test.cc
+++ b/csrc/loader/stages/tensor_generator_test.cc
@@ -3,6 +3,7 @@
 
 #include "loader/stages/tensor_generator.h"
 
+#include <cmath>
 #include <cstring>
 #include <memory>
 #include <vector>
@@ -84,6 +85,7 @@ class TensorGeneratorTest : public ::testing::Test {
     frame.best_d = 0.1f;
     frame.best_m = 42.5f;
     frame.plies_left = 42.5f;
+    frame.plies_until_progress = 7;
 
     return frame;
   }
@@ -113,14 +115,14 @@ class TensorGeneratorTest : public ::testing::Test {
     EXPECT_EQ(probs_tensor->shape()[0], batch_size);
     EXPECT_EQ(probs_tensor->shape()[1], 1858);
 
-    // Verify values tensor: (batch_size, 6, 3)
+    // Verify values tensor: (batch_size, 6, 4)
     const auto* values_tensor =
         dynamic_cast<const TypedTensor<float>*>(tensors[2].get());
     ASSERT_NE(values_tensor, nullptr);
     EXPECT_EQ(values_tensor->shape().size(), 3);
     EXPECT_EQ(values_tensor->shape()[0], batch_size);
     EXPECT_EQ(values_tensor->shape()[1], 6);
-    EXPECT_EQ(values_tensor->shape()[2], 3);
+    EXPECT_EQ(values_tensor->shape()[2], 4);
   }
 
   void VerifyTensorData(const TensorTuple& tensors,
@@ -142,17 +144,19 @@ class TensorGeneratorTest : public ::testing::Test {
         EXPECT_FLOAT_EQ(probs_slice[j], frame.probabilities[j]);
       }
 
-      // Verify values tensor [batch, 6, 3] with raw q/d/m values
-      // Index 0: result (q=0.5, d=0.2, m=42.5)
+      // Verify values tensor [batch, 6, 4] with raw q/d/m/p values.
+      // Index 0: result (q=0.5, d=0.2, m=42.5, p=7).
       auto values_slice = values_tensor->slice({static_cast<ssize_t>(i)});
-      EXPECT_FLOAT_EQ(values_slice[0 * 3 + 0], 0.5f);   // result_q
-      EXPECT_FLOAT_EQ(values_slice[0 * 3 + 1], 0.2f);   // result_d
-      EXPECT_FLOAT_EQ(values_slice[0 * 3 + 2], 42.5f);  // result_m
+      EXPECT_FLOAT_EQ(values_slice[0 * 4 + 0], 0.5f);   // result_q
+      EXPECT_FLOAT_EQ(values_slice[0 * 4 + 1], 0.2f);   // result_d
+      EXPECT_FLOAT_EQ(values_slice[0 * 4 + 2], 42.5f);  // result_m
+      EXPECT_FLOAT_EQ(values_slice[0 * 4 + 3], 7.0f);   // plies_until_progress
 
-      // Index 1: best (q=0.3, d=0.1, m=42.5)
-      EXPECT_FLOAT_EQ(values_slice[1 * 3 + 0], 0.3f);   // best_q
-      EXPECT_FLOAT_EQ(values_slice[1 * 3 + 1], 0.1f);   // best_d
-      EXPECT_FLOAT_EQ(values_slice[1 * 3 + 2], 42.5f);  // best_m
+      // Index 1: best (q=0.3, d=0.1, m=42.5, p=NaN).
+      EXPECT_FLOAT_EQ(values_slice[1 * 4 + 0], 0.3f);    // best_q
+      EXPECT_FLOAT_EQ(values_slice[1 * 4 + 1], 0.1f);    // best_d
+      EXPECT_FLOAT_EQ(values_slice[1 * 4 + 2], 42.5f);   // best_m
+      EXPECT_TRUE(std::isnan(values_slice[1 * 4 + 3]));  // p: NaN (non-result)
 
       // Verify planes data - check first few planes and meta planes.
       auto planes_slice = planes_tensor->slice({static_cast<ssize_t>(i)});
@@ -350,6 +354,8 @@ TEST_F(TensorGeneratorTest, VerifiesQDConversion) {
   frame.result_d = 0.3f;
   frame.best_q = -0.2f;
   frame.best_d = 0.1f;
+  // 0xff means "unknown" and must map to NaN.
+  frame.plies_until_progress = 0xff;
 
   producer.Put(frame);
   producer.Close();
@@ -361,12 +367,13 @@ TEST_F(TensorGeneratorTest, VerifiesQDConversion) {
   auto values_slice = values_tensor->slice({0});
 
   // Verify result values: q=0.4, d=0.3 (raw values, no WDL conversion)
-  EXPECT_FLOAT_EQ(values_slice[0 * 3 + 0], 0.4f);  // result_q
-  EXPECT_FLOAT_EQ(values_slice[0 * 3 + 1], 0.3f);  // result_d
+  EXPECT_FLOAT_EQ(values_slice[0 * 4 + 0], 0.4f);    // result_q
+  EXPECT_FLOAT_EQ(values_slice[0 * 4 + 1], 0.3f);    // result_d
+  EXPECT_TRUE(std::isnan(values_slice[0 * 4 + 3]));  // 0xff -> NaN
 
   // Verify best values: q=-0.2, d=0.1 (raw values, no WDL conversion)
-  EXPECT_FLOAT_EQ(values_slice[1 * 3 + 0], -0.2f);  // best_q
-  EXPECT_FLOAT_EQ(values_slice[1 * 3 + 1], 0.1f);   // best_d
+  EXPECT_FLOAT_EQ(values_slice[1 * 4 + 0], -0.2f);  // best_q
+  EXPECT_FLOAT_EQ(values_slice[1 * 4 + 1], 0.1f);   // best_d
 }
 
 }  // namespace training

--- a/csrc/tools/dump_chunk_main.cc
+++ b/csrc/tools/dump_chunk_main.cc
@@ -15,6 +15,7 @@
 #include <string>
 
 #include "trainingdata/trainingdata_v6.h"
+#include "trainingdata/trainingdata_v7.h"
 #include "utils/training_data_printer.h"
 
 ABSL_FLAG(std::string, chunk_path, "", "Path to the chunk file (.gz) to dump.");
@@ -30,9 +31,6 @@ namespace training {
 
 namespace {
 
-using ::lczero::training::FrameType;
-using ::lczero::training::PrintTrainingDataEntry;
-
 void DumpChunk(const std::string& path, int64_t max_entries,
                int64_t float_per_line, int64_t plane_per_line) {
   gzFile file = gzopen(path.c_str(), "rb");
@@ -42,7 +40,7 @@ void DumpChunk(const std::string& path, int64_t max_entries,
 
   size_t index = 0;
   while (true) {
-    FrameType entry;
+    V7TrainingData entry;
     const int bytes_read = gzread(file, &entry, sizeof(entry));
     if (bytes_read == 0) {
       break;

--- a/csrc/tools/result_distribution_main.cc
+++ b/csrc/tools/result_distribution_main.cc
@@ -24,6 +24,7 @@
 
 #include "loader/chunk_source/tar_chunk_source.h"
 #include "trainingdata/trainingdata_v6.h"
+#include "trainingdata/trainingdata_v7.h"
 
 ABSL_FLAG(std::string, output_csv, "",
           "Destination CSV file. Writes to stdout if empty.");
@@ -34,8 +35,8 @@ namespace {
 
 namespace fs = std::filesystem;
 
+using ::lczero::V7TrainingData;
 using ::lczero::training::ChunkSourceLoaderConfig;
-using ::lczero::training::FrameType;
 using ::lczero::training::TarChunkSource;
 
 enum class ChunkResult { kWin, kDraw, kLoss };
@@ -79,13 +80,13 @@ constexpr float kFloatTolerance = 1e-6f;
 std::optional<ChunkResult> DetermineChunkResult(absl::string_view chunk_payload,
                                                 size_t chunk_index,
                                                 const fs::path& tar_path) {
-  if (chunk_payload.size() < sizeof(FrameType)) {
+  if (chunk_payload.size() < sizeof(V7TrainingData)) {
     LOG(WARNING) << "Chunk " << chunk_index << " in " << tar_path.string()
                  << " is too small.";
     return std::nullopt;
   }
 
-  FrameType frame;
+  V7TrainingData frame;
   std::memcpy(&frame, chunk_payload.data(), sizeof(frame));
 
   if (std::fabs(frame.result_d - 1.0f) <= kFloatTolerance) {
@@ -118,7 +119,7 @@ ResultCounts CountResultsInTar(const fs::path& tar_path) {
   const size_t chunk_count = source.GetChunkCount();
   for (size_t index = 0; index < chunk_count; ++index) {
     const std::optional<std::string> chunk =
-        source.GetChunkPrefix(index, sizeof(FrameType));
+        source.GetChunkPrefix(index, sizeof(V7TrainingData));
     if (!chunk) {
       LOG(WARNING) << "Skipping unreadable chunk " << index << " in "
                    << tar_path.string();

--- a/docs/example.textproto
+++ b/docs/example.textproto
@@ -112,6 +112,7 @@ model {
   policy_head { name: "vanilla" embedding_size: 1024 d_model: 1024 }
   value_head { name: "winner" num_channels: 128 }
   movesleft_head { name: "main" num_channels: 32 }
+  movesleft_head { name: "progress" num_channels: 32 }
 }
 training {
   schedule {
@@ -177,7 +178,26 @@ training {
       temperature: 1.0  # Softmax temperature applied before KL evaluation
     }
     value { head_name: "winner" weight: 1.0 }
-    movesleft { head_name: "main" weight: 1.0 }
+    # MOVES_LEFT reads values[RESULT, 2] = plies_left. component, scale and
+    # huber_delta are all required (no defaults).
+    movesleft {
+      head_name: "main"
+      value_type: RESULT
+      component: MOVES_LEFT
+      weight: 1.0
+      scale: 0.05
+      huber_delta: 10.0
+    }
+    # Plies until the next progress move (values[RESULT, 3]). NaN targets
+    # (unknown positions) are masked out by the loss.
+    movesleft {
+      head_name: "progress"
+      value_type: RESULT
+      component: PLIES_UNTIL_PROGRESS
+      weight: 0.5
+      scale: 0.1
+      huber_delta: 5.0
+    }
   }
 }
 metrics {

--- a/proto/training_config.proto
+++ b/proto/training_config.proto
@@ -169,7 +169,22 @@ message MovesLeftLossConfig {
   string head_name = 1;
   string metric_name = 2;
   float weight = 3;
+  // Selects the value-type row of the values[6,4] tensor.
   ValueType value_type = 4;
+  // Selects the component column of the values tensor; the enum value is the
+  // column index. Defaults to COMPONENT_Q (column 0).
+  enum Component {
+    COMPONENT_Q = 0;           // values[value_type, 0]
+    COMPONENT_D = 1;           // values[value_type, 1]
+    MOVES_LEFT = 2;            // values[value_type, 2]
+    PLIES_UNTIL_PROGRESS = 3;  // values[value_type, 3]
+  }
+  Component component = 5;
+  // `scale` multiplies prediction and target before the Huber loss (e.g. 0.05
+  // to bring plies into ~unit range). `huber_delta` is the Huber threshold in
+  // plies. Both must be set to a positive value (no default).
+  float scale = 6;
+  float huber_delta = 7;
 }
 
 message ValueErrorLossConfig {

--- a/src/lczero_training/commands/train.py
+++ b/src/lczero_training/commands/train.py
@@ -99,6 +99,7 @@ def train(config_filename: str) -> None:
             min_version="0.28",
             num_heads=training_state.num_heads,
             license=None,
+            training_steps=new_state.step,
         )
         export_state = (
             new_state.swa_state

--- a/src/lczero_training/daemon/pipeline.py
+++ b/src/lczero_training/daemon/pipeline.py
@@ -249,6 +249,7 @@ class TrainingPipeline:
             min_version="0.31",
             num_heads=self._training_state.num_heads,
             license=None,
+            training_steps=self._training_state.jit_state.step,
         )
         export_state = (
             self._training_state.jit_state.swa_state

--- a/src/lczero_training/model/loss_function.py
+++ b/src/lczero_training/model/loss_function.py
@@ -28,6 +28,22 @@ def _compute_q_from_wdl(wdl_logits: jax.Array) -> jax.Array:
     return jnp.dot(wdl_probs, q_weights)
 
 
+def _mask_nan_target(loss: jax.Array, *targets: jax.Array) -> jax.Array:
+    """Zero `loss` (per sample) when any target element is NaN.
+
+    NaN targets mark positions that must not train: `plies_until_progress` is
+    NaN for unknown positions (truncated games / after the last progress move),
+    and some value-type targets (e.g. ORIG) can be NaN as well.
+
+    `loss` must already be finite -- callers compute it from a sanitized target
+    (NaN replaced via `jnp.nan_to_num`) so reverse-mode gradients stay clean;
+    this only selects between the finite `loss` and 0.0. Note that a masked
+    sample still counts in the batch-mean denominator (slight dilution).
+    """
+    finite = jnp.all(jnp.stack([jnp.all(~jnp.isnan(t)) for t in targets]))
+    return jnp.where(finite, loss, 0.0)
+
+
 class LossBase:
     def __init__(
         self,
@@ -190,20 +206,23 @@ class ValueLoss(LossBase):
     ) -> jax.Array:
         value_pred = predictions.value[self.head_name]
         value_logits = value_pred[0]
-        # Extract raw q/d from sample and compute WDL.
+        # Extract raw q/d from sample and compute WDL. Sanitize NaN targets
+        # (e.g. ORIG) before use; the loss is masked out below.
         value_q = sample.values[self.value_type, 0]
         value_d = sample.values[self.value_type, 1]
+        q = jnp.nan_to_num(value_q)
+        d = jnp.nan_to_num(value_d)
         # Compute WDL: w = (1 + q - d) / 2, l = (1 - q - d) / 2
-        value_w = (1.0 + value_q - value_d) / 2.0
-        value_l = (1.0 - value_q - value_d) / 2.0
-        value_wdl = jnp.stack([value_w, value_d, value_l], axis=-1)
+        value_w = (1.0 + q - d) / 2.0
+        value_l = (1.0 - q - d) / 2.0
+        value_wdl = jnp.stack([value_w, d, value_l], axis=-1)
 
         # The cross-entropy between the predicted value and the target value.
         value_cross_entropy = optax.softmax_cross_entropy(
             logits=value_logits, labels=jax.lax.stop_gradient(value_wdl)
         )
         assert isinstance(value_cross_entropy, jax.Array)
-        return value_cross_entropy
+        return _mask_nan_target(value_cross_entropy, value_q, value_d)
 
 
 class PolicyLoss(LossBase):
@@ -324,6 +343,30 @@ class MovesLeftLoss(LossBase):
     def __init__(self, config: MovesLeftLossConfig) -> None:
         super().__init__(config)
         self.value_type = config.value_type
+        # `component` enum values are column indices into values[6, 4]
+        # (Q=0, D=1, MOVES_LEFT=2, PLIES_UNTIL_PROGRESS=3). Regressing a
+        # moves-left head onto q/d is rejected (remove if ever needed).
+        if config.component not in (
+            MovesLeftLossConfig.MOVES_LEFT,
+            MovesLeftLossConfig.PLIES_UNTIL_PROGRESS,
+        ):
+            raise ValueError(
+                f"movesleft loss '{config.head_name}' component must be "
+                "MOVES_LEFT or PLIES_UNTIL_PROGRESS."
+            )
+        self.component = config.component
+        # `scale` multiplies prediction and target (e.g. 0.05); `huber_delta`
+        # is the Huber threshold in plies. Both must be set explicitly.
+        if config.scale <= 0:
+            raise ValueError(
+                f"movesleft loss '{config.head_name}' must set scale > 0."
+            )
+        if config.huber_delta <= 0:
+            raise ValueError(
+                f"movesleft loss '{config.head_name}' must set huber_delta > 0."
+            )
+        self.scale = config.scale
+        self.huber_delta = config.huber_delta
 
     def __call__(
         self,
@@ -331,21 +374,22 @@ class MovesLeftLoss(LossBase):
         sample: TrainingSample,
     ) -> jax.Array:
         movesleft_pred = predictions.movesleft[self.head_name]
-        # Extract movesleft from sample.
-        # sample.values shape: [6, 3], component 2 is movesleft.
-        movesleft_targets = sample.values[self.value_type, 2]
+        # sample.values shape: [6, 4]; component is the column index.
+        movesleft_targets = sample.values[self.value_type, self.component]
 
-        # Scale the loss to similar range as other losses.
-        scale = 20.0
-        targets = movesleft_targets / scale
-        scaled_predictions = movesleft_pred / scale
+        # Scale the loss to a similar range as other losses. Sanitize NaN
+        # targets (unknown positions) before computing; masked out below.
+        targets = jnp.nan_to_num(movesleft_targets) * self.scale
+        scaled_predictions = movesleft_pred * self.scale
 
-        # Huber loss
+        # Huber loss (delta is in plies, so scale it the same way).
         huber_loss = optax.huber_loss(
-            predictions=scaled_predictions, targets=targets, delta=10.0 / scale
+            predictions=scaled_predictions,
+            targets=targets,
+            delta=self.huber_delta * self.scale,
         )
         assert isinstance(huber_loss, jax.Array)
-        return huber_loss.squeeze()
+        return _mask_nan_target(huber_loss.squeeze(), movesleft_targets)
 
 
 class ValueErrorLoss(LossBase):
@@ -367,11 +411,13 @@ class ValueErrorLoss(LossBase):
         # Convert WDL to Q value.
         predicted_q = _compute_q_from_wdl(wdl_logits)
 
-        # Get target Q value.
+        # Get target Q value (sanitize NaN; masked out below).
         target_q = sample.values[self.value_type, 0]
 
         # Compute actual squared error.
-        actual_squared_error = jnp.square(predicted_q - target_q)
+        actual_squared_error = jnp.square(
+            predicted_q - jnp.nan_to_num(target_q)
+        )
 
         # Optionally block gradients to WDL head.
         if not self.propagate_value_gradients:
@@ -380,7 +426,7 @@ class ValueErrorLoss(LossBase):
         # MSE between error prediction and actual error.
         loss = jnp.square(error_pred - actual_squared_error)
 
-        return loss.squeeze()
+        return _mask_nan_target(loss.squeeze(), target_q)
 
 
 class ValueCategoricalLoss(LossBase):
@@ -397,14 +443,14 @@ class ValueCategoricalLoss(LossBase):
         categorical_logits = value_pred[2]
         assert categorical_logits is not None
 
-        # Get target Q value from sample.
+        # Get target Q value from sample (sanitize NaN; masked out below).
         target_q = sample.values[self.value_type, 0]
 
         # Convert Q to bucket index: map [-1, 1) to [0, num_buckets).
         num_buckets = categorical_logits.shape[-1]
-        bucket_index = jnp.floor((target_q + 1.0) / 2.0 * num_buckets).astype(
-            jnp.int32
-        )
+        bucket_index = jnp.floor(
+            (jnp.nan_to_num(target_q) + 1.0) / 2.0 * num_buckets
+        ).astype(jnp.int32)
         bucket_index = jnp.clip(bucket_index, 0, num_buckets - 1)
 
         # Create one-hot target.
@@ -416,4 +462,4 @@ class ValueCategoricalLoss(LossBase):
             labels=jax.lax.stop_gradient(target_one_hot),
         )
         assert isinstance(loss, jax.Array)
-        return loss
+        return _mask_nan_target(loss, target_q)

--- a/src/lczero_training/model/test_loss_function.py
+++ b/src/lczero_training/model/test_loss_function.py
@@ -1,0 +1,121 @@
+import jax
+import jax.numpy as jnp
+import pytest
+
+from lczero_training.model.loss_function import MovesLeftLoss, ValueLoss
+from lczero_training.model.model import ModelPrediction
+from lczero_training.training.state import TrainingSample
+from proto import training_config_pb2 as tc
+
+NAN = float("nan")
+
+
+def _valid_movesleft_config() -> tc.MovesLeftLossConfig:
+    return tc.MovesLeftLossConfig(
+        head_name="progress",
+        value_type=tc.RESULT,
+        component=tc.MovesLeftLossConfig.PLIES_UNTIL_PROGRESS,
+        weight=0.5,
+        scale=0.1,
+        huber_delta=5.0,
+    )
+
+
+def _sample(progress: float) -> TrainingSample:
+    # values[6, 4]; RESULT row holds [q, d, m, plies_until_progress].
+    values = jnp.zeros((6, 4))
+    values = values.at[tc.RESULT].set(jnp.array([0.5, 0.2, 42.5, progress]))
+    return TrainingSample(
+        inputs=jnp.zeros((112, 8, 8)),
+        probabilities=jnp.zeros((1858,)),
+        values=values,
+    )
+
+
+def _movesleft_pred(value: float) -> ModelPrediction:
+    return ModelPrediction(
+        value={}, policy={}, movesleft={"progress": jnp.array([value])}
+    )
+
+
+@pytest.mark.parametrize("field", ["scale", "huber_delta"])
+def test_movesleft_requires_positive_scaling(field: str) -> None:
+    cfg = _valid_movesleft_config()
+    setattr(cfg, field, 0.0)
+    with pytest.raises(ValueError):
+        MovesLeftLoss(cfg)
+
+
+@pytest.mark.parametrize(
+    "component",
+    [
+        tc.MovesLeftLossConfig.COMPONENT_Q,
+        tc.MovesLeftLossConfig.COMPONENT_D,
+    ],
+)
+def test_movesleft_rejects_q_d_component(component: int) -> None:
+    cfg = _valid_movesleft_config()
+    setattr(cfg, "component", component)
+    with pytest.raises(ValueError):
+        MovesLeftLoss(cfg)
+
+
+def test_movesleft_component_selects_column() -> None:
+    # RESULT row is [q=0.5, d=0.2, m=42.5, p=7]; a prediction matching the
+    # selected column gives zero loss, proving component picks the column.
+    pred = _movesleft_pred(7.0)
+    sample = _sample(7.0)
+
+    p_cfg = _valid_movesleft_config()  # PLIES_UNTIL_PROGRESS -> col 3 = 7
+    assert float(MovesLeftLoss(p_cfg)(pred, sample)) == 0.0
+
+    m_cfg = _valid_movesleft_config()
+    m_cfg.component = tc.MovesLeftLossConfig.MOVES_LEFT  # col 2 = 42.5
+    assert float(MovesLeftLoss(m_cfg)(pred, sample)) > 0.0
+
+
+def test_movesleft_finite_target_has_loss() -> None:
+    loss = MovesLeftLoss(_valid_movesleft_config())
+    value = float(loss(_movesleft_pred(3.0), _sample(7.0)))
+    assert value > 0.0
+
+
+def test_movesleft_nan_target_is_masked_with_finite_grad() -> None:
+    loss = MovesLeftLoss(_valid_movesleft_config())
+
+    def loss_of_pred(pred: float) -> jax.Array:
+        return loss(_movesleft_pred(pred), _sample(NAN))
+
+    assert float(loss_of_pred(3.0)) == 0.0
+    grad = jax.grad(loss_of_pred)(3.0)
+    assert float(grad) == 0.0
+    assert bool(jnp.isfinite(grad))
+
+
+def test_value_loss_masks_nan_target() -> None:
+    # ORIG q/d may be NaN; that sample must contribute zero with finite grad.
+    loss = ValueLoss(
+        tc.ValueLossConfig(head_name="winner", value_type=tc.RESULT)
+    )
+
+    def loss_of_logits(logits: jax.Array, progress: float) -> jax.Array:
+        nan_q_d = (
+            jnp.zeros((6, 4))
+            .at[tc.RESULT]
+            .set(jnp.array([NAN, NAN, 0.0, progress]))
+        )
+        sample = TrainingSample(
+            inputs=jnp.zeros((112, 8, 8)),
+            probabilities=jnp.zeros((1858,)),
+            values=nan_q_d,
+        )
+        pred = ModelPrediction(
+            value={"winner": (logits, None, None)}, policy={}, movesleft={}
+        )
+        return loss(pred, sample)
+
+    logits = jnp.array([0.1, 0.2, 0.3])
+    assert float(loss_of_logits(logits, 0.0)) == 0.0
+    grad = jax.grad(loss_of_logits)(logits, 0.0)
+    assert bool(jnp.all(jnp.isfinite(grad)))
+    assert float(jnp.sum(jnp.abs(grad))) == 0.0

--- a/src/lczero_training/training/optimizer.py
+++ b/src/lczero_training/training/optimizer.py
@@ -31,14 +31,14 @@ def update_optimizer_step(
     )
 
     # Verify no count fields were missed due to unknown wrapper types.
-    def find_unexpected_counts(x: object) -> bool:
+    def has_unexpected_count(x: object) -> bool:
         return (
-            hasattr(x, "count")
-            and hasattr(x, "_replace")
+            hasattr(x, "_fields")
+            and "count" in x._fields
             and not isinstance(x, _STATES_WITH_COUNT)
         )
 
-    unexpected = jax.tree.leaves(result, is_leaf=find_unexpected_counts)
+    unexpected = jax.tree.leaves(result, is_leaf=has_unexpected_count)
     assert not unexpected, (
         f"Unexpected state type(s) with 'count' field: "
         f"{[type(x).__name__ for x in unexpected]}"

--- a/src/lczero_training/training/optimizer.py
+++ b/src/lczero_training/training/optimizer.py
@@ -20,31 +20,18 @@ def update_optimizer_step(
     """Updates all step counters in the optimizer state tree."""
     step_array = jnp.array(step, dtype=jnp.int32)
 
-    def is_known_state(x: object) -> bool:
-        return isinstance(x, _STATES_WITH_COUNT)
+    def has_count(x: object) -> bool:
+        return hasattr(x, "_fields") and "count" in x._fields
 
     def update_count(x: optax.OptState) -> optax.OptState:
+        if not has_count(x):
+            return x
+        assert isinstance(x, _STATES_WITH_COUNT), (
+            f"Unexpected state type with 'count' field: {type(x).__name__}"
+        )
         return x._replace(count=step_array)
 
-    result = jax.tree_util.tree_map(
-        update_count, opt_state, is_leaf=is_known_state
-    )
-
-    # Verify no count fields were missed due to unknown wrapper types.
-    def has_unexpected_count(x: object) -> bool:
-        return (
-            hasattr(x, "_fields")
-            and "count" in x._fields
-            and not isinstance(x, _STATES_WITH_COUNT)
-        )
-
-    unexpected = jax.tree.leaves(result, is_leaf=has_unexpected_count)
-    assert not unexpected, (
-        f"Unexpected state type(s) with 'count' field: "
-        f"{[type(x).__name__ for x in unexpected]}"
-    )
-
-    return result
+    return jax.tree_util.tree_map(update_count, opt_state, is_leaf=has_count)
 
 
 def make_gradient_transformation(

--- a/src/lczero_training/training/optimizer.py
+++ b/src/lczero_training/training/optimizer.py
@@ -3,6 +3,7 @@ from functools import partial
 import jax
 import jax.numpy as jnp
 import optax
+from flax import nnx
 
 from lczero_training.training.utils import make_weights_mask
 from proto.training_config_pb2 import OptimizerConfig
@@ -70,10 +71,13 @@ def make_gradient_transformation(
     if max_grad_norm is not None and max_grad_norm > 0:
         tx = optax.chain(optax.clip_by_global_norm(max_grad_norm), tx)
     if config.HasField("freeze_selector"):
-        tx = optax.masked(
-            tx,
-            mask=lambda p: jax.tree.map(
-                lambda x: not x, make_weights_mask(config.freeze_selector, p)
-            ),
+        freeze_mask = partial(make_weights_mask, config.freeze_selector)
+
+        def trainable_mask(p: nnx.State) -> nnx.State:
+            return jax.tree.map(lambda x: not x, freeze_mask(p))
+
+        tx = optax.chain(
+            optax.masked(tx, trainable_mask),
+            optax.masked(optax.set_to_zero(), freeze_mask),
         )
     return tx

--- a/src/lczero_training/training/optimizer.py
+++ b/src/lczero_training/training/optimizer.py
@@ -8,6 +8,11 @@ from flax import nnx
 from lczero_training.training.utils import make_weights_mask
 from proto.training_config_pb2 import OptimizerConfig
 
+_STATES_WITH_COUNT = (
+    optax.ScaleByAdamState,
+    optax.ScaleByScheduleState,
+)
+
 
 def update_optimizer_step(
     opt_state: optax.OptState, step: int
@@ -15,20 +20,31 @@ def update_optimizer_step(
     """Updates all step counters in the optimizer state tree."""
     step_array = jnp.array(step, dtype=jnp.int32)
 
-    def update_count(x: optax.OptState) -> optax.OptState:
-        if isinstance(
-            x,
-            (
-                optax.ScaleByAdamState,
-                optax.ScaleByScheduleState,
-            ),
-        ):
-            return x._replace(count=step_array)
-        return x
+    def is_known_state(x: object) -> bool:
+        return isinstance(x, _STATES_WITH_COUNT)
 
-    return jax.tree_util.tree_map(
-        update_count, opt_state, is_leaf=lambda x: hasattr(x, "_replace")
+    def update_count(x: optax.OptState) -> optax.OptState:
+        return x._replace(count=step_array)
+
+    result = jax.tree_util.tree_map(
+        update_count, opt_state, is_leaf=is_known_state
     )
+
+    # Verify no count fields were missed due to unknown wrapper types.
+    def find_unexpected_counts(x: object) -> bool:
+        return (
+            hasattr(x, "count")
+            and hasattr(x, "_replace")
+            and not isinstance(x, _STATES_WITH_COUNT)
+        )
+
+    unexpected = jax.tree.leaves(result, is_leaf=find_unexpected_counts)
+    assert not unexpected, (
+        f"Unexpected state type(s) with 'count' field: "
+        f"{[type(x).__name__ for x in unexpected]}"
+    )
+
+    return result
 
 
 def make_gradient_transformation(

--- a/src/lczero_training/training/state.py
+++ b/src/lczero_training/training/state.py
@@ -32,13 +32,16 @@ class TrainingSample:
     Fields:
         inputs: Input planes tensor [112, 8, 8]
         probabilities: Policy probabilities tensor [1858]
-        values: Combined values tensor [6, 3] where:
-            - Index 0: result [result_q, result_d, plies_left]
-            - Index 1: best [best_q, best_d, best_m]
-            - Index 2: played [played_q, played_d, played_m]
-            - Index 3: orig [orig_q, orig_d, orig_m] (may contain NaN)
-            - Index 4: root [root_q, root_d, root_m]
-            - Index 5: st [q_st, d_st, NaN]
+        values: Combined values tensor [6, 4] of [q, d, m, p] per row, where:
+            - Index 0: result [result_q, result_d, plies_left,
+              plies_until_progress]
+            - Index 1: best [best_q, best_d, best_m, NaN]
+            - Index 2: played [played_q, played_d, played_m, NaN]
+            - Index 3: orig [orig_q, orig_d, orig_m, NaN] (q/d/m may be NaN)
+            - Index 4: root [root_q, root_d, root_m, NaN]
+            - Index 5: st [q_st, d_st, NaN, NaN]
+            Component 3 (p) holds plies_until_progress on the result row only
+            (NaN for unknown positions); NaN targets are masked by the loss.
     """
 
     inputs: jax.Array
@@ -54,13 +57,16 @@ class TrainingBatch:
     Fields:
         inputs: Input planes tensor [batch, 112, 8, 8]
         probabilities: Policy probabilities tensor [batch, 1858]
-        values: Combined values tensor [batch, 6, 3] where:
-            - Index 0: result [result_q, result_d, plies_left]
-            - Index 1: best [best_q, best_d, best_m]
-            - Index 2: played [played_q, played_d, played_m]
-            - Index 3: orig [orig_q, orig_d, orig_m] (may contain NaN)
-            - Index 4: root [root_q, root_d, root_m]
-            - Index 5: st [q_st, d_st, NaN]
+        values: Combined values tensor [batch, 6, 4] of [q, d, m, p] per row:
+            - Index 0: result [result_q, result_d, plies_left,
+              plies_until_progress]
+            - Index 1: best [best_q, best_d, best_m, NaN]
+            - Index 2: played [played_q, played_d, played_m, NaN]
+            - Index 3: orig [orig_q, orig_d, orig_m, NaN] (q/d/m may be NaN)
+            - Index 4: root [root_q, root_d, root_m, NaN]
+            - Index 5: st [q_st, d_st, NaN, NaN]
+            Component 3 (p) holds plies_until_progress on the result row only
+            (NaN for unknown positions); NaN targets are masked by the loss.
     """
 
     inputs: Union[jax.Array, jshard.NamedSharding]

--- a/src/lczero_training/training/training.py
+++ b/src/lczero_training/training/training.py
@@ -304,6 +304,7 @@ class Training:
         if self._dp_sharding is not None:
             replicated = jshard.NamedSharding(self._dp_sharding.mesh, P())
             jit_state = jax.device_put(jit_state, replicated)
+        batch = self._validate_and_prepare_batch(next(datagen))
         for local_step in range(num_steps):
             logger.info(f"Starting step {jit_state.step}")
             if memory_profile_dir is not None:
@@ -312,10 +313,12 @@ class Training:
                     f"{datetime.now().strftime('%Y%m%d-%H%M%S')}"
                     f"_before_{int(jit_state.step)}.prof"
                 )
-            batch = self._validate_and_prepare_batch(next(datagen))
             jit_state, metrics = self.train_step(
                 self.optimizer_tx, jit_state, batch
             )
+            next_batch = None
+            if local_step + 1 < num_steps:
+                next_batch = self._validate_and_prepare_batch(next(datagen))
             step_value = int(
                 np.asarray(jax.device_get(jit_state.step)).reshape(())
             )
@@ -326,4 +329,6 @@ class Training:
                 step_hook, step_value, local_step, num_steps, metrics, jit_state
             )
             self._log_step_metrics(step_value, local_step, num_steps, metrics)
+            if next_batch is not None:
+                batch = next_batch
         return jit_state

--- a/src/lczero_training/training/training.py
+++ b/src/lczero_training/training/training.py
@@ -304,7 +304,6 @@ class Training:
         if self._dp_sharding is not None:
             replicated = jshard.NamedSharding(self._dp_sharding.mesh, P())
             jit_state = jax.device_put(jit_state, replicated)
-        batch = self._validate_and_prepare_batch(next(datagen))
         for local_step in range(num_steps):
             logger.info(f"Starting step {jit_state.step}")
             if memory_profile_dir is not None:
@@ -313,12 +312,10 @@ class Training:
                     f"{datetime.now().strftime('%Y%m%d-%H%M%S')}"
                     f"_before_{int(jit_state.step)}.prof"
                 )
+            batch = self._validate_and_prepare_batch(next(datagen))
             jit_state, metrics = self.train_step(
                 self.optimizer_tx, jit_state, batch
             )
-            next_batch = None
-            if local_step + 1 < num_steps:
-                next_batch = self._validate_and_prepare_batch(next(datagen))
             step_value = int(
                 np.asarray(jax.device_get(jit_state.step)).reshape(())
             )
@@ -329,6 +326,4 @@ class Training:
                 step_hook, step_value, local_step, num_steps, metrics, jit_state
             )
             self._log_step_metrics(step_value, local_step, num_steps, metrics)
-            if next_batch is not None:
-                batch = next_batch
         return jit_state


### PR DESCRIPTION
Exposes the per-frame `plies_until_progress` signal (computed by `FillPliesUntilProgress`) to training as a second moves-left-style scalar head, and tidies up moves-left target selection.

## Data
- Extend the values tensor `[6,3] → [6,4]` (`[q, d, m, p]` per value type). Component 3 (`p`) carries `plies_until_progress` on the **RESULT** row only (NaN elsewhere). The `0xff` "unknown" sentinel (truncated games / positions after the last progress move) maps to **NaN**.
- Rename `ply_until_progress → plies_until_progress` (and `FillPlyUntilProgress → FillPliesUntilProgress`) for consistency.

## Loss config
- `MovesLeftLossConfig` gains a `Component` enum (`Q=0, D=1, MOVES_LEFT=2, PLIES_UNTIL_PROGRESS=3`) selecting the target column, plus required `scale` (a multiplier, e.g. `0.05`) and `huber_delta` (threshold in plies). `Q`/`D` are rejected for moves-left losses; no silent defaults.
- The progress head needs **no new model code** — `MovesLeftHead` is reused via config.

## NaN masking
- Data losses (`MovesLeft`/`Value`/`ValueError`/`ValueCategorical`) now zero their contribution per-sample when the target is NaN. Targets are sanitized before the loss so gradients stay finite, then masked. Also fixes latent NaN poisoning from `ORIG` targets.

## Tests / docs
- New `model/test_loss_function.py` (component selection, Q/D rejection, required scaling, NaN masking with finite grads).
- C++ `tensor_generator_test` / `chunk_rescorer_test` updated for `[6,4]` + the NaN sentinel.
- `docs/example.textproto` demonstrates a `progress` head + loss.

All checks green via `just pre-commit` (clang-format, ruff, mypy, 16/16 C++ tests, 29/29 pytest).

> Note: not yet verified end-to-end in the TUI.